### PR TITLE
feat: multi level querying

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,13 @@
 {
   "permissions": {
-    "allow": ["WebSearch", "Bash(npx vitest *)"]
+    "allow": [
+      "WebSearch",
+      "Bash(npx vitest *)",
+      "WebFetch(domain:github.com)",
+      "Bash(pnpm test *)",
+      "Bash(pnpm build *)",
+      "Bash(pnpm lint *)",
+      "Bash(pnpm docs:build)"
+    ]
   }
 }

--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -21,7 +21,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: "pnpm"
       - run: pnpm i
       - run: pnpm lint
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     env:
       DB: sqlite
 
@@ -51,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         postgres-version: [14, 15, 16, 17, latest] # see https://hub.docker.com/_/postgres
 
     services:
@@ -85,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         mysql-version: [lts, latest] # see https://hub.docker.com/_/mysql/
 
     services:

--- a/docs/relations/belongs-to.md
+++ b/docs/relations/belongs-to.md
@@ -23,6 +23,30 @@ new KyselyService<User>({
 
 In this example, each user can optionally belong to a manager (a self-referencing relation).
 
+## Querying
+
+Filter parent records by a belongsTo relation's column using dot notation or nested notation — both produce the same SQL.
+
+```ts
+// Dot notation
+await app.service("todos").find({
+  query: { "user.name": "Alice" },
+});
+
+// Nested notation
+await app.service("todos").find({
+  query: { user: { name: "Alice" } },
+});
+```
+
+Operators work on the leaf column:
+
+```ts
+await app.service("todos").find({
+  query: { "user.age": { $gt: 30 } },
+});
+```
+
 ## Sorting
 
 You can sort by a belongsTo relation's column using dot notation:
@@ -35,3 +59,57 @@ await app.service("users").find({
 ```
 
 For belongsTo relations, this translates to a simple `LEFT JOIN` — no aggregation is needed since there is at most one related record.
+
+## Multi-level chains
+
+You can chain belongsTo relations across any number of hops. Each hop is resolved through the target service's own `relations` definition.
+
+Given an `events` service that belongsTo `assignments`, which belongsTo `customers`:
+
+```ts
+// Dot notation
+await app.service("events").find({
+  query: { "assignment.customer.fullName": "Acme Corp" },
+});
+
+// Nested notation (equivalent)
+await app.service("events").find({
+  query: { assignment: { customer: { fullName: "Acme Corp" } } },
+});
+```
+
+Each service declares only its own direct relations — the adapter walks the chain at query time by looking up the target service via `app.service(name)`.
+
+### Operators and sorting work at any depth
+
+```ts
+// Filter with an operator at the leaf
+await app.service("events").find({
+  query: { "assignment.customer.createdAt": { $gt: "2026-01-01" } },
+});
+
+// Sort by a deep column
+await app.service("events").find({
+  query: { $sort: { "assignment.customer.fullName": 1 } },
+});
+```
+
+### SQL output
+
+Chained paths produce one `LEFT JOIN` per hop, with aliases built by joining the relation keys with `__`:
+
+```sql
+SELECT events.* FROM events
+LEFT JOIN assignments AS assignment          ON assignment.id = events.assignmentId
+LEFT JOIN customers   AS assignment__customer ON assignment__customer.id = assignment.customerId
+WHERE assignment__customer.fullName = 'Acme Corp'
+```
+
+Paths that share a prefix deduplicate their JOINs — `'assignment.customer.fullName'` and `'assignment.number'` in the same query only join `assignments` once.
+
+### Requirements and limits
+
+- **`app.setup()` must have run** — the adapter needs the Feathers app to look up related services. See [Setup → App Setup](./setup#app-setup).
+- **belongsTo only** — chains through hasMany (e.g. `'user.todos.text'`) are silently ignored. Use `$some` / `$none` / `$every` for hasMany — see [Querying Relations](./querying).
+- **Same-adapter services** — the related service must also be a `KyselyService`. Paths through foreign adapters are silently skipped.
+- **Broken paths are silent** — if any segment doesn't resolve (unknown relation, typo), the filter is ignored rather than throwing. Double-check your relation definitions if a query returns unexpected rows.

--- a/docs/relations/querying.md
+++ b/docs/relations/querying.md
@@ -1,5 +1,23 @@
 # Querying Relations
 
+## belongsTo
+
+For `asArray: false` (belongsTo) relations, filter by the related record's columns using dot notation or nested notation. This translates to a `LEFT JOIN`. Chains of any depth are supported — see [belongsTo → Multi-level chains](./belongs-to#multi-level-chains) for details.
+
+```ts
+// 1-level (either form works)
+await app.service("todos").find({
+  query: { "user.name": "Alice" },
+});
+
+// Multi-level
+await app.service("events").find({
+  query: { "assignment.customer.fullName": "Acme Corp" },
+});
+```
+
+## hasMany
+
 For `asArray: true` (hasMany) relations, you can filter parent records based on conditions on their children using `$some`, `$none`, and `$every`.
 
 ## `$some`

--- a/docs/relations/setup.md
+++ b/docs/relations/setup.md
@@ -66,3 +66,13 @@ users.id ← todos.userId
 ```
 
 See [hasMany](./has-many) for details.
+
+## App Setup
+
+If you plan to query or sort by [multi-level belongsTo chains](./belongs-to#multi-level-chains) (e.g. `event.assignment.customer.fullName`), make sure `app.setup()` runs before the first query. Feathers calls it automatically when you start the server via `app.listen()`. In tests or programmatic usage without `listen()`, invoke it explicitly:
+
+```ts
+await app.setup();
+```
+
+This is how the adapter discovers the relation definitions of _other_ services when resolving a chained path. Single-level queries work without it.

--- a/docs/relations/sorting.md
+++ b/docs/relations/sorting.md
@@ -15,6 +15,19 @@ await app.service("users").find({
 
 Since there is at most one related record, no aggregation is needed.
 
+### Multi-level belongsTo
+
+You can sort by a column reached through any number of belongsTo hops. Each hop becomes a `LEFT JOIN`:
+
+```ts
+// Sort events by their assignment's customer's full name
+await app.service("events").find({
+  query: { $sort: { "assignment.customer.fullName": 1 } },
+});
+```
+
+Requires `app.setup()` to have run so the adapter can look up related services — see [Setup → App Setup](./setup#app-setup). For more on chained paths, see [belongsTo → Multi-level chains](./belongs-to#multi-level-chains).
+
 ## hasMany Sorting
 
 For hasMany (`asArray: true`) relations, sorting uses a subquery with an aggregate function to avoid duplicating parent rows:

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -19,6 +19,7 @@ import type {
   DialectType,
   KyselyAdapterOptions,
   KyselyAdapterParams,
+  Relation,
   UpsertOptions,
 } from './declarations.js'
 import { expressionBuilder, sql } from 'kysely'
@@ -117,6 +118,8 @@ export class KyselyAdapter<
 
   private propertyMap: Map<string, any>
 
+  protected app?: any
+
   constructor(options: KyselyAdapterOptions) {
     if (!options || !options.Model) {
       throw new Error(
@@ -153,6 +156,10 @@ export class KyselyAdapter<
       Object.entries(options.properties || {}),
     )
     // console.log(options.name, this.propertyMap)
+  }
+
+  async setup(app: any, _path: string) {
+    this.app = app
   }
 
   private getDatabaseDialect(db?: Kysely<any>): DialectType {
@@ -302,10 +309,14 @@ export class KyselyAdapter<
     let query = params.query || {}
     if (!this.options.relations) return { q, query }
 
+    // Normalize nested belongsTo notation to dot-notation so both JOIN analysis
+    // and WHERE-clause generation see a single canonical shape.
+    query = this.flattenRelationQuery(query)
+
     const alreadyJoined: string[] = []
 
     if (options.where) {
-      const whereResult = this.applyJoinsForWhere(q, params.query || {}, {
+      const whereResult = this.applyJoinsForWhere(q, query, {
         alreadyJoined,
       })
       q = whereResult.q
@@ -319,6 +330,173 @@ export class KyselyAdapter<
     return { q, query }
   }
 
+  private lookupRelationsForService(
+    serviceName: string,
+  ): Record<string, Relation> | undefined {
+    if (!this.app) return undefined
+    try {
+      const svc = this.app.service(serviceName)
+      return svc?.options?.relations
+    } catch {
+      return undefined
+    }
+  }
+
+  private isPlainRelationObject(value: any): boolean {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+    const keys = Object.keys(value)
+    if (keys.length === 0) return false
+    // Operator-only map (e.g. { $gt: 5 }) or collection operators ({ $some: ... })
+    // should be treated as a leaf, not traversed further.
+    if (keys.every((k) => k.startsWith('$'))) return false
+    return true
+  }
+
+  private flattenRelationQuery(query: Query): Query {
+    if (!this.options.relations || !query) return query
+
+    const out: Record<string, any> = {}
+
+    for (const key in query) {
+      const value = query[key]
+
+      if (FILTERS.includes(key as Filter)) {
+        out[key] = value
+        continue
+      }
+
+      if (key === '$and' || key === '$or') {
+        if (Array.isArray(value)) {
+          out[key] = value.map((sub) => this.flattenRelationQuery(sub))
+        } else {
+          out[key] = value
+        }
+        continue
+      }
+
+      const relation = this.options.relations[key]
+      if (
+        relation &&
+        !relation.asArray &&
+        this.isPlainRelationObject(value)
+      ) {
+        this.flattenBelongsToInto(
+          value,
+          [key],
+          out,
+          this.lookupRelationsForService(relation.service),
+        )
+        continue
+      }
+
+      out[key] = value
+    }
+
+    return out
+  }
+
+  private flattenBelongsToInto(
+    obj: any,
+    prefix: string[],
+    out: Record<string, any>,
+    currentRelations: Record<string, Relation> | undefined,
+  ) {
+    for (const subKey in obj) {
+      const value = obj[subKey]
+      const nextRelation = currentRelations?.[subKey]
+      if (
+        nextRelation &&
+        !nextRelation.asArray &&
+        this.isPlainRelationObject(value)
+      ) {
+        this.flattenBelongsToInto(
+          value,
+          [...prefix, subKey],
+          out,
+          this.lookupRelationsForService(nextRelation.service),
+        )
+      } else {
+        out[[...prefix, subKey].join('.')] = value
+      }
+    }
+  }
+
+  private resolveRelationPath(parts: string[]): {
+    steps: Array<{
+      relation: Relation
+      alias: string
+      sourceAlias: string
+      databaseTableName: string
+      sourceKey: string
+      targetKey: string
+    }>
+    columnAlias: string
+    columnName: string
+    isSimpleColumn: boolean
+  } | null {
+    if (!parts.length) return null
+    if (parts.length === 1) {
+      return {
+        steps: [],
+        columnAlias: this.options.name,
+        columnName: parts[0],
+        isSimpleColumn: true,
+      }
+    }
+
+    const steps: Array<{
+      relation: Relation
+      alias: string
+      sourceAlias: string
+      databaseTableName: string
+      sourceKey: string
+      targetKey: string
+    }> = []
+
+    let currentRelations = this.options.relations
+    let currentAlias = this.options.name
+    const aliasChain: string[] = []
+
+    for (let i = 0; i < parts.length - 1; i++) {
+      const key = parts[i]
+      const relation = currentRelations?.[key]
+
+      if (
+        !relation ||
+        relation.asArray ||
+        !relation.databaseTableName ||
+        !relation.keyHere ||
+        !relation.keyThere
+      ) {
+        return null
+      }
+
+      aliasChain.push(key)
+      const alias = aliasChain.join('__')
+
+      if (steps.some((s) => s.alias === alias)) return null
+
+      steps.push({
+        relation,
+        alias,
+        sourceAlias: currentAlias,
+        databaseTableName: relation.databaseTableName,
+        sourceKey: relation.keyHere,
+        targetKey: relation.keyThere,
+      })
+
+      currentAlias = alias
+      currentRelations = this.lookupRelationsForService(relation.service)
+    }
+
+    return {
+      steps,
+      columnAlias: currentAlias,
+      columnName: parts[parts.length - 1],
+      isSimpleColumn: false,
+    }
+  }
+
   private applyJoinsForWhere<Q extends Record<string, any>>(
     q: Q,
     query: Query,
@@ -327,8 +505,6 @@ export class KyselyAdapter<
     },
   ): { q: Q; query: Query } {
     if (!this.options.relations) return { q, query }
-
-    const cloned = false
 
     for (const key in query) {
       if (FILTERS.includes(key as Filter)) continue
@@ -357,51 +533,35 @@ export class KyselyAdapter<
         }
 
         if (query[key] !== array) {
-          if (!cloned) {
-            query = { ...query }
-          }
-
-          query[key] = array
+          query = { ...query, [key]: array }
         }
 
         continue
       }
 
-      let relation = this.options.relations[key]
-      let relationKey = key
+      if (!key.includes('.')) continue
 
-      if (!relation && key.includes('.')) {
-        const parts = key.split('.')
-        if (parts.length !== 2) continue
-
-        relationKey = parts[0]
-        relation = this.options.relations[relationKey]
-      }
-
-      if (
-        !relation ||
-        !relation.databaseTableName ||
-        !relation.keyHere ||
-        !relation.keyThere ||
-        relation.asArray /** only apply joins for belongsTo relations */
-      )
+      const parts = key.split('.')
+      const resolved = this.resolveRelationPath(parts)
+      if (!resolved || resolved.isSimpleColumn || resolved.steps.length === 0)
         continue
 
-      if (options.alreadyJoined.includes(relationKey)) continue
+      for (const step of resolved.steps) {
+        if (options.alreadyJoined.includes(step.alias)) continue
 
-      const { databaseTableName, keyHere, keyThere } = relation
+        q = q.leftJoin(
+          `${step.databaseTableName} as ${step.alias}`,
+          `${step.alias}.${step.targetKey}`,
+          `${step.sourceAlias}.${step.sourceKey}`,
+        )
 
-      q = q.leftJoin(
-        `${databaseTableName} as ${relationKey}`,
-        `${relationKey}.${keyThere}`,
-        `${this.options.name}.${keyHere}`,
-      )
+        options.alreadyJoined.push(step.alias)
+      }
 
+      const last = resolved.steps[resolved.steps.length - 1]
       query = addToQuery(query, {
-        [`${relationKey}.${keyThere}`]: { $ne: null },
+        [`${last.alias}.${last.targetKey}`]: { $ne: null },
       })
-
-      options.alreadyJoined.push(relationKey)
     }
 
     return { q, query }
@@ -478,6 +638,8 @@ export class KyselyAdapter<
 
     if (!relation) {
       const parts = queryKey.split('.')
+      // Multi-level paths through hasMany (e.g. 'user.todos.text') are not
+      // supported yet. Only direct `<hasMany>.<column>` is resolvable here.
       if (parts.length !== 2) return
 
       relationKey = parts[0]
@@ -570,54 +732,44 @@ export class KyselyAdapter<
   ) {
     if (!this.options.relations) return
 
-    let relation = this.options.relations[queryKey]
+    const directRelation = this.options.relations[queryKey]
 
-    if (!relation && !queryKey.includes('.')) {
+    if (!directRelation && !queryKey.includes('.')) {
       return
     }
 
-    let relationKey = queryKey
-    let nested = true
-
-    if (!relation) {
+    // Dot-notation path: resolve across any number of belongsTo hops.
+    if (!directRelation) {
       const parts = queryKey.split('.')
-      if (parts.length !== 2) return
+      const resolved = this.resolveRelationPath(parts)
+      if (!resolved || resolved.isSimpleColumn || resolved.steps.length === 0) {
+        return
+      }
 
-      relationKey = parts[0]
-      nested = false
-
-      relation = this.options.relations[relationKey]
+      const aliasedKey = `${resolved.columnAlias}.${resolved.columnName}`
+      return this.handleQueryPropertyNormal(eb, aliasedKey, queryProperty, {
+        tableName: null,
+      })
     }
 
+    // Nested notation: this path is entered when applyJoins did not flatten
+    // (e.g. inside buildHasManyExists). Preserves 1-level behavior.
     if (
-      !relation ||
-      !relation.databaseTableName ||
-      !relation.keyHere ||
-      !relation.keyThere ||
-      relation.asArray
+      !directRelation.databaseTableName ||
+      !directRelation.keyHere ||
+      !directRelation.keyThere ||
+      directRelation.asArray
     ) {
       return
     }
 
     const subQueries: ExpressionWrapper<any, any, any>[] = []
-
-    if (nested) {
-      for (const subKey in queryProperty) {
-        const subQuery = this.handleQueryProperty(
-          eb,
-          subKey,
-          queryProperty[subKey],
-          { tableName: relationKey },
-        )
-
-        if (subQuery) subQueries.push(subQuery)
-      }
-    } else {
-      const subQuery = this.handleQueryPropertyNormal(
+    for (const subKey in queryProperty) {
+      const subQuery = this.handleQueryProperty(
         eb,
-        queryKey,
-        queryProperty,
-        { tableName: null },
+        subKey,
+        queryProperty[subKey],
+        { tableName: queryKey },
       )
 
       if (subQuery) subQueries.push(subQuery)
@@ -732,34 +884,25 @@ export class KyselyAdapter<
   ): Q {
     if (!this.options.relations || !$sort) return q
 
-    if (!$sort) return q
-
     for (const key in $sort) {
       if (!key.includes('.')) continue
 
-      const mapKey = key.split('.')[0]
-
-      const map = this.options.relations[mapKey]
-      if (
-        !map ||
-        !map.databaseTableName ||
-        !map.keyHere ||
-        !map.keyThere ||
-        map.asArray /** only apply joins for belongsTo relations */
-      )
+      const parts = key.split('.')
+      const resolved = this.resolveRelationPath(parts)
+      if (!resolved || resolved.isSimpleColumn || resolved.steps.length === 0)
         continue
 
-      if (options.alreadyJoined.includes(mapKey)) continue
+      for (const step of resolved.steps) {
+        if (options.alreadyJoined.includes(step.alias)) continue
 
-      const { databaseTableName, keyHere, keyThere } = map
+        q = q.leftJoin(
+          `${step.databaseTableName} as ${step.alias}`,
+          `${step.alias}.${step.targetKey}`,
+          `${step.sourceAlias}.${step.sourceKey}`,
+        )
 
-      q = q.leftJoin(
-        `${databaseTableName} as ${mapKey}`,
-        `${mapKey}.${keyThere}`,
-        `${this.options.name}.${keyHere}`,
-      )
-
-      options.alreadyJoined.push(mapKey)
+        options.alreadyJoined.push(step.alias)
+      }
     }
 
     return q
@@ -855,6 +998,15 @@ export class KyselyAdapter<
 
     if (belongsTo) return belongsTo
 
+    // Unresolved dot-paths whose first segment names a known relation are
+    // silently skipped (e.g. broken chains like 'user.bogus.name', or
+    // out-of-scope hasMany chains like 'todos.user.name'). Without this,
+    // the raw dot-path would leak into WHERE as an invalid column ref.
+    if (queryKey.includes('.') && this.options.relations) {
+      const firstPart = queryKey.split('.')[0]
+      if (this.options.relations[firstPart]) return undefined
+    }
+
     const json = this.handleJson(eb, queryKey, queryProperty)
 
     if (json) return json
@@ -925,6 +1077,17 @@ export class KyselyAdapter<
           const subquery = sql`(SELECT ${sql.raw(aggFn)}(${sql.ref(`${relationKey}.${column}`)}) FROM ${sql.table(relation.databaseTableName)} AS ${sql.ref(relationKey)} WHERE ${sql.ref(`${relationKey}.${relation.keyThere}`)} = ${sql.ref(`${this.options.name}.${relation.keyHere}`)}${filter ? this.buildHasManySortFilter(relationKey, filter) : sql.raw('')})`
 
           q = q.orderBy(subquery, getOrderByModifier(value)) as any
+          continue
+        }
+
+        // belongsTo chain (1..N hops): rewrite to the aliased column ref
+        const parts = key.split('.')
+        const resolved = this.resolveRelationPath(parts)
+        if (resolved && !resolved.isSimpleColumn && resolved.steps.length > 0) {
+          q = q.orderBy(
+            `${resolved.columnAlias}.${resolved.columnName}`,
+            getOrderByModifier(value),
+          ) as any
           continue
         }
       }

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -7,7 +7,7 @@ import type { ControlledTransaction, Kysely } from 'kysely'
 
 export type DialectType = 'mysql' | 'postgres' | 'sqlite' | 'mssql'
 
-type Relation = {
+export type Relation = {
   service: string
   keyHere: string
   keyThere: string

--- a/test/relations.test.ts
+++ b/test/relations.test.ts
@@ -5,7 +5,7 @@ import { feathers } from '@feathersjs/feathers'
 import dialect from './dialect.js'
 
 import { KyselyService } from '../src/index.js'
-import { describe, it } from 'vitest'
+import { beforeAll, describe, it } from 'vitest'
 import { addPrimaryKey } from './test-utils.js'
 
 function setup() {
@@ -169,6 +169,7 @@ function setup() {
 const { app, db, clean } = setup()
 
 describe('relations', () => {
+  beforeAll(() => app.setup())
   beforeEach(clean)
 
   afterAll(() => db.destroy())
@@ -325,6 +326,38 @@ describe('relations', () => {
 
     const result = await app.service('users').find({
       query: { todos: { $some: { text: { $like: '%first%' } } } },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 2)
+    assert.ok(result.find((u) => u.name === 'Alice'))
+    assert.ok(result.find((u) => u.name === 'Bob'))
+  })
+
+  it('query for hasMany with $some and $or', async () => {
+    const users = await app.service('users').create([
+      { name: 'Alice', age: 30 },
+      { name: 'Bob', age: 25 },
+      { name: 'Charlie', age: 35 },
+    ])
+
+    await app.service('todos').create([
+      { text: 'urgent task', userId: users[0].id },
+      { text: 'normal todo', userId: users[1].id },
+      { text: 'boring note', userId: users[2].id },
+    ])
+
+    // Users who have a todo with text matching 'urgent' OR 'todo'
+    const result = await app.service('users').find({
+      query: {
+        todos: {
+          $some: {
+            $or: [
+              { text: { $like: '%urgent%' } },
+              { text: { $like: '%todo%' } },
+            ],
+          },
+        },
+      },
       paginate: false,
     })
     assert.strictEqual(result.length, 2)
@@ -648,27 +681,172 @@ describe('relations', () => {
     assert.strictEqual(result[0].text, 'Todo 1')
   })
 
-  // MARK: Multi-level relations (unsupported — graceful handling)
+  // MARK: Multi-level belongsTo
 
-  it('3-level dot notation is silently ignored', async () => {
-    const users = await app.service('users').create([
-      { name: 'Alice', age: 30 },
-      { name: 'Bob', age: 25 },
+  it('3-level dot notation filters through chained belongsTo', async () => {
+    const managers = await app
+      .service('users')
+      .create([{ name: 'Manager-A' }, { name: 'Manager-B' }])
+    const workers = await app.service('users').create([
+      { name: 'Alice', managerId: managers[0].id },
+      { name: 'Bob', managerId: managers[1].id },
+    ])
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: workers[0].id },
+      { text: 'Bob todo', userId: workers[1].id },
     ])
 
-    await app.service('todos').create({ text: 'Todo 1', userId: users[0].id })
+    const result = await app.service('todos').find({
+      query: { 'user.manager.name': 'Manager-A' },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].text, 'Alice todo')
+  })
 
-    // 3-level path should be silently skipped (parts.length !== 2)
-    try {
-      const result = await app.service('todos').find({
-        query: { 'user.manager.name': 'Alice' },
-        paginate: false,
-      })
-      // If no error, filter was ignored — all todos returned
-      assert.strictEqual(result.length, 1)
-    } catch {
-      // An error is also acceptable — the key point is it doesn't crash the DB
-    }
+  it('3-level nested notation produces the same result as dot notation', async () => {
+    const managers = await app
+      .service('users')
+      .create([{ name: 'Manager-A' }, { name: 'Manager-B' }])
+    const workers = await app.service('users').create([
+      { name: 'Alice', managerId: managers[0].id },
+      { name: 'Bob', managerId: managers[1].id },
+    ])
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: workers[0].id },
+      { text: 'Bob todo', userId: workers[1].id },
+    ])
+
+    const result = await app.service('todos').find({
+      query: { user: { manager: { name: 'Manager-B' } } },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].text, 'Bob todo')
+  })
+
+  it('3-level belongsTo with operator ($gt)', async () => {
+    const managers = await app.service('users').create([
+      { name: 'Manager-Old', age: 55 },
+      { name: 'Manager-Young', age: 30 },
+    ])
+    const workers = await app.service('users').create([
+      { name: 'Alice', managerId: managers[0].id },
+      { name: 'Bob', managerId: managers[1].id },
+    ])
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: workers[0].id },
+      { text: 'Bob todo', userId: workers[1].id },
+    ])
+
+    const result = await app.service('todos').find({
+      query: { 'user.manager.age': { $gt: 40 } },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].text, 'Alice todo')
+  })
+
+  it('3-level combined with 1-level sharing the same relation prefix', async () => {
+    const managers = await app.service('users').create([{ name: 'Manager-A' }])
+    const workers = await app.service('users').create([
+      { name: 'Alice', managerId: managers[0].id },
+      { name: 'Alicia', managerId: managers[0].id },
+    ])
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: workers[0].id },
+      { text: 'Alicia todo', userId: workers[1].id },
+    ])
+
+    const result = await app.service('todos').find({
+      query: {
+        'user.manager.name': 'Manager-A',
+        'user.name': 'Alice',
+      },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].text, 'Alice todo')
+  })
+
+  it('sort by 3-level belongsTo column', async () => {
+    const managers = await app
+      .service('users')
+      .create([{ name: 'Manager-Z' }, { name: 'Manager-A' }])
+    const workers = await app.service('users').create([
+      { name: 'Alice', managerId: managers[0].id },
+      { name: 'Bob', managerId: managers[1].id },
+    ])
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: workers[0].id },
+      { text: 'Bob todo', userId: workers[1].id },
+    ])
+
+    const result = await app.service('todos').find({
+      query: { $sort: { 'user.manager.name': 1 } },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 2)
+    // Bob's manager is Manager-A (first), Alice's is Manager-Z
+    assert.strictEqual(result[0].text, 'Bob todo')
+    assert.strictEqual(result[1].text, 'Alice todo')
+  })
+
+  it('3-level with $and filters', async () => {
+    const managers = await app.service('users').create([
+      { name: 'Manager-A', age: 50 },
+      { name: 'Manager-B', age: 30 },
+    ])
+    const workers = await app.service('users').create([
+      { name: 'Alice', managerId: managers[0].id },
+      { name: 'Bob', managerId: managers[1].id },
+    ])
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: workers[0].id },
+      { text: 'Bob todo', userId: workers[1].id },
+    ])
+
+    const result = await app.service('todos').find({
+      query: {
+        $and: [
+          { 'user.manager.name': 'Manager-A' },
+          { 'user.manager.age': { $gt: 40 } },
+        ],
+      },
+      paginate: false,
+    })
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].text, 'Alice todo')
+  })
+
+  it('3-level path with unknown middle segment is silently ignored', async () => {
+    await app.service('users').create([{ name: 'Alice' }, { name: 'Bob' }])
+    await app.service('todos').create({ text: 'Todo 1', userId: 1 })
+
+    const result = await app.service('todos').find({
+      query: { 'user.bogus.name': 'Alice' },
+      paginate: false,
+    })
+    // Unknown middle segment → resolver returns null, filter is skipped
+    assert.strictEqual(result.length, 1)
+  })
+
+  it('3-level path through hasMany is silently skipped', async () => {
+    const users = await app
+      .service('users')
+      .create([{ name: 'Alice' }, { name: 'Bob' }])
+
+    await app.service('todos').create([
+      { text: 'Alice todo', userId: users[0].id },
+      { text: 'Bob todo', userId: users[1].id },
+    ])
+
+    const result = await app.service('users').find({
+      query: { 'todos.user.name': 'Alice' },
+      paginate: false,
+    })
+    // hasMany in the middle of a path is out of scope → filter ignored
+    assert.strictEqual(result.length, 2)
   })
 
   it("sort by relation's column", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "feathers-kysely",
+  "compatibility_date": "2026-04-21",
+  "assets": {
+    "directory": "./docs/.vitepress/dist",
+    "not_found_handling": "404-page",
+  },
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for multi-level belongsTo relation querying and sorting in the Kysely adapter, along with extensive documentation and improved developer ergonomics. The main changes include enabling dot-notation and nested notation for deep relation chains, normalizing queries internally, updating the adapter to resolve and join across arbitrary belongsTo paths, and documenting the new capabilities and requirements.

**Major enhancements to belongsTo relation querying and sorting:**

* Added support for querying and sorting by columns across any number of belongsTo relation hops, using both dot-notation and nested notation (e.g., `"assignment.customer.fullName"`), with automatic LEFT JOIN generation and aliasing. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR333-R499) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL735-R905) [[3]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR1082-R1092) [[4]](diffhunk://#diff-3198ff679cdf9f49ce223d7087665f6f07b67c0dadd49f4812538f807d30e0e2R62-R115) [[5]](diffhunk://#diff-c642bd6a8b27bf40e37d5a0a97214f310eebf89e0512bfb1172afaf5d63ed733R18-R30) [[6]](diffhunk://#diff-cd1886d89a3f0a8f5ddbbbce305bd6160e634c91a493b5ed66a3a649cf0fcf43R3-R20)
* Implemented normalization of nested belongsTo queries to dot-notation, ensuring a single canonical query shape internally. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR312-R319) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR333-R499)
* The adapter now walks relation chains at query time by looking up each target service’s relations, supporting arbitrarily deep belongsTo paths. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR333-R499) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL735-R905)
* Enhanced error handling: broken or out-of-scope relation chains are silently ignored instead of throwing errors, and only valid belongsTo chains are joined. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR333-R499) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR1001-R1009)

**Documentation improvements:**

* Expanded documentation in `docs/relations/belongs-to.md`, `docs/relations/querying.md`, `docs/relations/sorting.md`, and `docs/relations/setup.md` to explain multi-level belongsTo chains, query normalization, SQL output, requirements (such as `app.setup()`), and limitations. [[1]](diffhunk://#diff-3198ff679cdf9f49ce223d7087665f6f07b67c0dadd49f4812538f807d30e0e2R26-R49) [[2]](diffhunk://#diff-3198ff679cdf9f49ce223d7087665f6f07b67c0dadd49f4812538f807d30e0e2R62-R115) [[3]](diffhunk://#diff-cd1886d89a3f0a8f5ddbbbce305bd6160e634c91a493b5ed66a3a649cf0fcf43R3-R20) [[4]](diffhunk://#diff-b29fbd9725e71f2f5eea4b7e900cdf8f243584ec5864efe46442cc03ea30b331R69-R78) [[5]](diffhunk://#diff-c642bd6a8b27bf40e37d5a0a97214f310eebf89e0512bfb1172afaf5d63ed733R18-R30)

**Adapter and test infrastructure updates:**

* Added `setup()` method to the adapter to store the Feathers app instance for relation lookup, and updated tests to call `app.setup()` before running queries. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR121-R122) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR161-R164) [[3]](diffhunk://#diff-eb1a25234dcd3d0a4c361d8c5408038fbd9c9f926a2204c550df4ecd877e0ce7L8-R8) [[4]](diffhunk://#diff-eb1a25234dcd3d0a4c361d8c5408038fbd9c9f926a2204c550df4ecd877e0ce7R172)
* Updated the `Relation` type export for clarity and consistency. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR22) [[2]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986L10-R10)

**Developer tooling:**

* Expanded allowed permissions in `.claude/settings.json` to include additional commands for testing, building, linting, and documentation.

These changes provide a more powerful and flexible API for querying and sorting by related data, with improved documentation and developer experience.