### PR TITLE
feat: new "withTransaction" around hook

### DIFF
--- a/docs/api/transactions.md
+++ b/docs/api/transactions.md
@@ -1,8 +1,92 @@
 # Transactions
 
-Transaction hooks wrap service calls in database transactions using Kysely's `ControlledTransaction` API.
+Wrap service calls in database transactions using Kysely's `ControlledTransaction`
+API. The recommended way is the `withTransaction()` **around hook**.
 
-## Using Hooks
+## Using the `withTransaction()` around hook (recommended)
+
+A single around hook handles the whole lifecycle: start → commit on success →
+rollback on error. It also **defers Feathers service events** until the
+transaction commits (and discards them on rollback), so listeners never react to
+data that was rolled back — including events from nested cross-service calls.
+
+Per method:
+
+```ts
+import { withTransaction } from "@fratzinger/feathers-kysely";
+
+app.service("users").hooks({
+  around: {
+    create: [withTransaction()],
+  },
+});
+```
+
+For **full cross-service event deferral**, register it app-wide. App-level
+around hooks run for every service and execute *inside* Feathers' internal
+event hook, which is exactly what makes deferral work:
+
+```ts
+app.hooks({
+  around: [withTransaction()],
+});
+```
+
+`withTransaction()` only engages for `create` / `update` / `patch` / `remove`.
+Every other method, and any non-Kysely or transaction-incapable service (e.g.
+in-memory SQLite), is a transparent passthrough — so app-level registration is
+safe across a mixed app.
+
+Root vs. nested is detected automatically: if `params.transaction` is already
+set, a savepoint is opened instead of a new root transaction. Forward
+`context.params.transaction` into nested service calls to include them:
+
+```ts
+app.service("users").hooks({
+  around: { create: [withTransaction()] },
+  before: {
+    create: [
+      async (context) => {
+        await context.app
+          .service("audit")
+          .create(
+            { message: "user created" },
+            { transaction: context.params.transaction },
+          );
+      },
+    ],
+  },
+});
+```
+
+### Event timing
+
+- On a successful **root** commit, all collected events
+  (`created`/`updated`/`patched`/`removed`), including those of nested
+  cross-service calls, are emitted in call order.
+- On rollback, no events are emitted at all.
+- Only the root transaction flushes; nested savepoints just queue onto it.
+
+For a nested service's event to be deferred it must also run through
+`withTransaction()` (per-service or app-level) and the call must forward
+`params.transaction`.
+
+## How event deferral works
+
+Feathers emits `created`/`updated`/… in an internal app-level *around* hook that
+wraps every method. `withTransaction()` runs inside it. After the wrapped method
+resolves, the hook captures the pending event into a root-transaction-scoped
+queue and clears `context.event` so the internal hook does not emit immediately.
+When the root transaction commits, the queue is flushed; on rollback it is
+discarded.
+
+## Legacy hooks (deprecated)
+
+::: warning Deprecated
+`trxStart` / `trxCommit` / `trxRollback` are kept for backward compatibility but
+are deprecated. They do **not** defer cross-service events. Prefer
+`withTransaction()`.
+:::
 
 ```ts
 import { trxStart, trxCommit, trxRollback } from "@fratzinger/feathers-kysely";
@@ -22,7 +106,10 @@ app.service("users").hooks({
 
 ## Using Params Directly
 
-You can manage transactions manually by passing a `transaction` object in `params`:
+You can manage transactions manually by passing a `transaction` object in
+`params`. This interoperates with `withTransaction()` — forward
+`context.params.transaction` into nested service calls and they join the same
+transaction:
 
 ```ts
 import type { KyselyAdapterTransaction } from "@fratzinger/feathers-kysely";
@@ -51,4 +138,8 @@ try {
 
 ## Nested Transactions (Savepoints)
 
-Nested transactions are supported by passing a transaction's `trx` to `startTransaction()` again.
+Nested transactions are backed by savepoints. When a `params.transaction` is
+already present, `withTransaction()` (and the legacy `trxStart()`) opens a
+savepoint via `trx.savepoint()` instead of a new root transaction, releasing it
+on success and rolling back to it on error. This happens automatically — just
+forward `context.params.transaction` into the nested service call.

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -36,8 +36,20 @@ export interface KyselyAdapterTransaction {
   id?: number
   starting: boolean
   parent?: KyselyAdapterTransaction
+  /**
+   * Name of the savepoint backing a nested transaction. Set only for nested
+   * transactions; root transactions commit/rollback the whole transaction.
+   */
+  savepoint?: string
   committed?: Promise<boolean | undefined>
   resolve?: (value: boolean) => void
+  /**
+   * Root-scoped queue of deferred Feathers event emitters. Populated by the
+   * `withTransaction()` around hook; flushed on root commit, discarded on root
+   * rollback. Nested transactions share the root's array. Undefined for legacy
+   * `trxStart()` transactions (no deferral).
+   */
+  deferredEvents?: Array<() => void>
 }
 
 export interface UpsertOptions<T = any> {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,7 @@
 import { createDebug } from '@feathersjs/commons'
-import type { HookContext } from '@feathersjs/feathers'
-import type { Kysely } from 'kysely'
+import type { HookContext, NextFunction } from '@feathersjs/feathers'
+import { getServiceOptions } from '@feathersjs/feathers'
+import type { ControlledTransaction, Kysely } from 'kysely'
 import type {
   KyselyAdapterParams,
   KyselyAdapterTransaction,
@@ -16,37 +17,131 @@ export const getKysely = (context: HookContext): Kysely<any> | undefined => {
   return db && typeof db.startTransaction === 'function' ? db : undefined
 }
 
+let savepointSeq = 0
+
+/**
+ * Starts a root transaction (`startTransaction()`) or, when an existing
+ * `params.transaction` is found, a nested transaction backed by a savepoint
+ * (`savepoint()`). Returns `undefined` (caller should pass through) when no
+ * Kysely instance / transaction is available.
+ */
+const startTransaction = async (
+  context: HookContext,
+  withDeferred: boolean,
+): Promise<KyselyAdapterTransaction | undefined> => {
+  const { transaction: parent } = context.params as KyselyAdapterParams
+
+  let trx: ControlledTransaction<any>
+  let savepoint: string | undefined
+
+  if (parent) {
+    savepoint = `fk_sp_${++savepointSeq}`
+    trx = await (parent.trx as any).savepoint(savepoint).execute()
+  } else {
+    const db = getKysely(context)
+    if (!db) {
+      return undefined
+    }
+    trx = await db.startTransaction().execute()
+  }
+
+  const transaction: KyselyAdapterTransaction = {
+    trx,
+    id: Date.now(),
+    starting: false,
+  }
+
+  if (parent) {
+    transaction.parent = parent
+    transaction.savepoint = savepoint
+    transaction.committed = parent.committed
+    if (withDeferred) {
+      // Share the root's queue so every nesting level pushes into one array.
+      transaction.deferredEvents = parent.deferredEvents
+    }
+  } else {
+    transaction.committed = new Promise((resolve) => {
+      transaction.resolve = resolve
+    })
+    if (withDeferred) {
+      transaction.deferredEvents = []
+    }
+  }
+
+  return transaction
+}
+
+const commitTransaction = async (
+  transaction: KyselyAdapterTransaction,
+): Promise<void> => {
+  const { trx, id, savepoint } = transaction
+
+  if (savepoint) {
+    await (trx as any).releaseSavepoint(savepoint).execute()
+  } else {
+    await trx.commit().execute()
+  }
+
+  if (transaction.resolve) {
+    transaction.resolve(true)
+  }
+
+  // Only the root flushes the shared deferred-event queue.
+  if (!transaction.parent && transaction.deferredEvents) {
+    const queue = transaction.deferredEvents
+    transaction.deferredEvents = []
+    for (const emit of queue) {
+      emit()
+    }
+  }
+
+  debug('ended transaction %s', id)
+}
+
+const rollbackTransaction = async (
+  transaction: KyselyAdapterTransaction,
+): Promise<void> => {
+  const { trx, id, savepoint } = transaction
+
+  if (savepoint) {
+    await (trx as any).rollbackToSavepoint(savepoint).execute()
+  } else {
+    await trx.rollback().execute()
+  }
+
+  if (transaction.resolve) {
+    transaction.resolve(false)
+  }
+
+  // Only the root owns the queue; discard everything that was deferred.
+  if (!transaction.parent && transaction.deferredEvents) {
+    transaction.deferredEvents.length = 0
+  }
+
+  debug('rolled back transaction %s', id)
+}
+
+/**
+ * @deprecated Use the `withTransaction()` around hook instead. Kept for
+ * backward compatibility; this legacy hook does NOT defer cross-service events.
+ */
 export const trxStart =
   () =>
   async (context: HookContext): Promise<void> => {
-    const { transaction: parent } = context.params as KyselyAdapterParams
-    const db: Kysely<any> | undefined = parent ? parent.trx : getKysely(context)
+    const transaction = await startTransaction(context, false)
 
-    if (!db) {
+    if (!transaction) {
       return
-    }
-
-    const trx = await db.startTransaction().execute()
-
-    const transaction: KyselyAdapterTransaction = {
-      trx,
-      id: Date.now(),
-      starting: false,
-    }
-
-    if (parent) {
-      transaction.parent = parent
-      transaction.committed = parent.committed
-    } else {
-      transaction.committed = new Promise((resolve) => {
-        transaction.resolve = resolve
-      })
     }
 
     context.params = { ...context.params, transaction }
     debug('started a new transaction %s', transaction.id)
   }
 
+/**
+ * @deprecated Use the `withTransaction()` around hook instead. Kept for
+ * backward compatibility; this legacy hook does NOT defer cross-service events.
+ */
 export const trxCommit = () => async (context: HookContext) => {
   const { transaction } = context.params as KyselyAdapterParams
 
@@ -54,21 +149,17 @@ export const trxCommit = () => async (context: HookContext) => {
     return
   }
 
-  const { trx, id, parent } = transaction
+  context.params = { ...context.params, transaction: transaction.parent }
 
-  context.params = { ...context.params, transaction: parent }
-
-  await trx.commit().execute()
-
-  if (transaction.resolve) {
-    transaction.resolve(true)
-  }
-
-  debug('ended transaction %s', id)
+  await commitTransaction(transaction)
 
   return context
 }
 
+/**
+ * @deprecated Use the `withTransaction()` around hook instead. Kept for
+ * backward compatibility; this legacy hook does NOT defer cross-service events.
+ */
 export const trxRollback = () => async (context: HookContext) => {
   const { transaction } = context.params as KyselyAdapterParams
 
@@ -76,17 +167,83 @@ export const trxRollback = () => async (context: HookContext) => {
     return
   }
 
-  const { trx, id, parent } = transaction
+  context.params = { ...context.params, transaction: transaction.parent }
 
-  context.params = { ...context.params, transaction: parent }
-
-  await trx.rollback().execute()
-
-  if (transaction.resolve) {
-    transaction.resolve(false)
-  }
-
-  debug('rolled back transaction %s', id)
+  await rollbackTransaction(transaction)
 
   return context
 }
+
+const MUTATING_METHODS = new Set(['create', 'update', 'patch', 'remove'])
+
+/**
+ * Around hook that wraps a service method in a Kysely `ControlledTransaction`:
+ * start → commit on success → rollback on error. Nested calls that forward
+ * `params.transaction` automatically use savepoints. Feathers service events
+ * (`created`/`updated`/`patched`/`removed`) are deferred and only emitted once
+ * the root transaction commits — and discarded on rollback — including events
+ * from nested cross-service calls.
+ *
+ * Register per method (`around: { create: [withTransaction()] }`) or, for full
+ * cross-service deferral, app-wide (`app.hooks({ around: [withTransaction()] })`).
+ * Only engages for `create`/`update`/`patch`/`remove`; every other method and
+ * any non-Kysely / transaction-incapable service is a transparent passthrough.
+ */
+export const withTransaction =
+  () =>
+  async (context: HookContext, next: NextFunction): Promise<void> => {
+    if (!MUTATING_METHODS.has(context.method)) {
+      await next()
+      return
+    }
+
+    const parent = (context.params as KyselyAdapterParams).transaction
+    const transaction = await startTransaction(context, true)
+
+    if (!transaction) {
+      await next()
+      return
+    }
+
+    context.params = { ...context.params, transaction }
+    debug('started a new transaction %s', transaction.id)
+
+    try {
+      await next()
+
+      // Capture this call's pending event into the shared root queue and
+      // suppress the outer Feathers `eventHook` so nothing is emitted before
+      // the root commits. Mirrors @feathersjs/feathers/lib/events.js exactly.
+      const self = context.self
+      const event = context.event
+      if (typeof event === 'string' && transaction.deferredEvents) {
+        const events = getServiceOptions(self).events ?? []
+        if (!events.includes(event)) {
+          const results = Array.isArray(context.result)
+            ? context.result
+            : [context.result]
+          for (const element of results) {
+            transaction.deferredEvents.push(() =>
+              self.emit(event, element, context),
+            )
+          }
+        }
+        context.event = null
+      }
+
+      context.params = { ...context.params, transaction: parent }
+      await commitTransaction(transaction)
+    } catch (error) {
+      context.params = { ...context.params, transaction: parent }
+      try {
+        await rollbackTransaction(transaction)
+      } catch (rollbackError) {
+        debug('rollback after error failed %o', rollbackError)
+      }
+      throw error
+    } finally {
+      if ((context.params as KyselyAdapterParams).transaction === transaction) {
+        context.params = { ...context.params, transaction: parent }
+      }
+    }
+  }

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -20,6 +20,7 @@ describe('exports', () => {
         'trxCommit',
         'trxRollback',
         'trxStart',
+        'withTransaction',
       ].sort(),
     )
   })

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -7,9 +7,10 @@ import {
   trxStart,
   trxCommit,
   trxRollback,
+  withTransaction,
 } from '../src/index.js'
 import type { KyselyAdapterTransaction } from '../src/index.js'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { addPrimaryKey } from './test-utils.js'
 
 interface AccountsTable {
@@ -231,5 +232,517 @@ describe.skipIf(dialectName === 'sqlite')('transactions', () => {
       const all = await accounts.find({ paginate: false })
       expect(all).toHaveLength(0)
     })
+  })
+
+  describe('withTransaction around hook', () => {
+    type Audit = { id: number; message: string }
+
+    const auditClean = async () => {
+      await db.schema.dropTable('audit').ifExists().execute()
+      await addPrimaryKey(
+        (db as Kysely<any>).schema
+          .createTable('audit')
+          .addColumn('message', 'text', (col) => col.notNull()),
+        'id',
+      ).execute()
+    }
+    beforeEach(auditClean)
+
+    function createCrossApp() {
+      return feathers<{
+        accounts: KyselyService<Account>
+        audit: KyselyService<Audit>
+      }>()
+        .use(
+          'accounts',
+          new KyselyService<Account>({
+            Model: db,
+            name: 'accounts',
+            multi: true,
+          }),
+        )
+        .use(
+          'audit',
+          new KyselyService<Audit>({ Model: db, name: 'audit', multi: true }),
+        )
+    }
+
+    it('commits data on success', async () => {
+      const svc = createApp().service('accounts')
+      svc.hooks({ around: { create: [withTransaction()] } })
+
+      await svc.create({ name: 'Wt1', balance: 1 })
+
+      const all = await accounts.find({ paginate: false })
+      expect(all).toHaveLength(1)
+    })
+
+    it('rolls back on error', async () => {
+      const svc = createApp().service('accounts')
+      svc.hooks({
+        around: { create: [withTransaction()] },
+        after: {
+          create: [
+            () => {
+              throw new Error('boom')
+            },
+          ],
+        },
+      })
+
+      await expect(svc.create({ name: 'Wt2', balance: 2 })).rejects.toThrow(
+        'boom',
+      )
+
+      const all = await accounts.find({ paginate: false })
+      expect(all).toHaveLength(0)
+    })
+
+    it('commits all rows for a multi create', async () => {
+      const svc = createApp().service('accounts')
+      svc.hooks({ around: { create: [withTransaction()] } })
+
+      await svc.create([
+        { name: 'M1', balance: 1 },
+        { name: 'M2', balance: 2 },
+      ])
+
+      const all = await accounts.find({ paginate: false })
+      expect(all).toHaveLength(2)
+    })
+
+    it('emits created once, only after commit', async () => {
+      const svc = createApp().service('accounts')
+      svc.hooks({ around: { create: [withTransaction()] } })
+
+      let count = 0
+      let visibleOutsideTrx = -1
+      const fired = new Promise<void>((resolve) => {
+        svc.on('created', async () => {
+          count++
+          const rows = await accounts.find({ paginate: false })
+          visibleOutsideTrx = rows.length
+          resolve()
+        })
+      })
+
+      await svc.create({ name: 'Evt', balance: 1 })
+      await fired
+
+      expect(count).toBe(1)
+      // visible from a separate connection => already committed when emitted
+      expect(visibleOutsideTrx).toBe(1)
+    })
+
+    it('find/get within the transaction see uncommitted rows (mutating-only engagement keeps the trx)', async () => {
+      const cross = createCrossApp()
+      // app-wide: find/get pass through withTransaction(), create starts a trx
+      cross.hooks({ around: [withTransaction()] })
+      const a = cross.service('accounts')
+
+      let findWithinTrx = -1
+      let getWithinTrx = false
+      a.hooks({
+        after: {
+          create: [
+            async (context) => {
+              const trx = (context.params as any).transaction
+              const rows = await a.find({
+                paginate: false,
+                transaction: trx,
+              } as any)
+              findWithinTrx = (rows as Account[]).length
+              const one = await a.get((context.result as any).id, {
+                transaction: trx,
+              } as any)
+              getWithinTrx = !!one
+              // not visible from a separate connection yet (still open)
+              expect(await accounts.find({ paginate: false })).toHaveLength(0)
+            },
+          ],
+        },
+      })
+
+      await a.create({ name: 'TrxRead', balance: 1 })
+
+      expect(findWithinTrx).toBe(1)
+      expect(getWithinTrx).toBe(true)
+      expect(await accounts.find({ paginate: false })).toHaveLength(1)
+    })
+
+    it('defers a nested cross-service event until root commit', async () => {
+      const cross = createCrossApp()
+      const a = cross.service('accounts')
+      const b = cross.service('audit')
+
+      a.hooks({
+        around: { create: [withTransaction()] },
+        before: {
+          create: [
+            async (context) => {
+              await cross.service('audit').create({ message: 'audited' }, {
+                transaction: (context.params as any).transaction,
+              } as any)
+            },
+          ],
+        },
+      })
+      b.hooks({ around: { create: [withTransaction()] } })
+
+      let auditVisibleAtEmit = -1
+      const auditCreated = new Promise<void>((resolve) => {
+        b.on('created', async () => {
+          const rows = await b.find({ paginate: false })
+          auditVisibleAtEmit = rows.length
+          resolve()
+        })
+      })
+
+      await a.create({ name: 'Cross', balance: 1 })
+      await auditCreated
+
+      expect(auditVisibleAtEmit).toBe(1)
+      expect(await accounts.find({ paginate: false })).toHaveLength(1)
+      expect(await b.find({ paginate: false })).toHaveLength(1)
+    })
+
+    it('discards a nested cross-service event on rollback', async () => {
+      const cross = createCrossApp()
+      const a = cross.service('accounts')
+      const b = cross.service('audit')
+
+      a.hooks({
+        around: { create: [withTransaction()] },
+        before: {
+          create: [
+            async (context) => {
+              await cross.service('audit').create({ message: 'audited' }, {
+                transaction: (context.params as any).transaction,
+              } as any)
+            },
+          ],
+        },
+        after: {
+          create: [
+            () => {
+              throw new Error('rollback-it')
+            },
+          ],
+        },
+      })
+      b.hooks({ around: { create: [withTransaction()] } })
+
+      const spy = vi.fn()
+      b.on('created', spy)
+
+      await expect(a.create({ name: 'CrossFail', balance: 1 })).rejects.toThrow(
+        'rollback-it',
+      )
+
+      expect(spy).not.toHaveBeenCalled()
+      expect(await accounts.find({ paginate: false })).toHaveLength(0)
+      expect(await b.find({ paginate: false })).toHaveLength(0)
+    })
+  })
+})
+
+// These exercise the deferral / suppression / queue mechanics with a stubbed
+// ControlledTransaction and plain services, so they run on every dialect
+// (including in-memory SQLite) without needing a real cross-connection trx.
+describe('withTransaction event deferral (stubbed transaction)', () => {
+  function makeTrx(log: string[], label: string) {
+    const trx: any = {
+      startTransaction: () => ({
+        execute: async () => makeTrx(log, label),
+      }),
+      commit: () => ({
+        execute: async () => {
+          log.push(`commit:${label}`)
+        },
+      }),
+      rollback: () => ({
+        execute: async () => {
+          log.push(`rollback:${label}`)
+        },
+      }),
+      savepoint: () => ({
+        execute: async () => makeTrx(log, `${label}>sp`),
+      }),
+      releaseSavepoint: () => ({
+        execute: async () => {
+          log.push(`commit:${label}`)
+        },
+      }),
+      rollbackToSavepoint: () => ({
+        execute: async () => {
+          log.push(`rollback:${label}`)
+        },
+      }),
+    }
+    return trx
+  }
+
+  class StubService {
+    log: string[]
+    failCreate = false
+    withModel: boolean
+    onCreate?: (data: any, params: any) => Promise<void>
+
+    constructor(log: string[], withModel = true) {
+      this.log = log
+      this.withModel = withModel
+    }
+
+    getModel() {
+      if (!this.withModel) return undefined
+      const log = this.log
+      return {
+        startTransaction: () => ({
+          execute: async () => makeTrx(log, 'root'),
+        }),
+      }
+    }
+
+    async find() {
+      return []
+    }
+
+    async create(data: any, params: any) {
+      this.log.push('create')
+      if (this.onCreate) await this.onCreate(data, params)
+      if (this.failCreate) throw new Error('create failed')
+      return { id: 1, ...data }
+    }
+  }
+
+  function appWith(...services: [string, any][]) {
+    const app = feathers()
+    for (const [name, svc] of services) app.use(name, svc)
+    return app
+  }
+
+  it('passes non-mutating methods through untouched', async () => {
+    const log: string[] = []
+    const app = appWith(['s', new StubService(log)])
+    const s = app.service('s')
+    s.hooks({
+      around: { find: [withTransaction()], create: [withTransaction()] },
+    })
+
+    await s.find()
+
+    expect(log).toEqual([]) // no transaction started for find
+  })
+
+  it('passes through and still emits when no Kysely db is available', async () => {
+    const log: string[] = []
+    const app = appWith(['s', new StubService(log, /* withModel */ false)])
+    const s = app.service('s')
+    s.hooks({ around: { create: [withTransaction()] } })
+
+    const events: string[] = []
+    s.on('created', () => events.push('created'))
+
+    await s.create({ a: 1 })
+
+    expect(log).toEqual(['create']) // no commit/rollback
+    expect(events).toEqual(['created']) // normal (non-deferred) emission
+  })
+
+  it('commits and emits the event only after commit', async () => {
+    const log: string[] = []
+    const app = appWith(['s', new StubService(log)])
+    const s = app.service('s')
+    s.hooks({ around: { create: [withTransaction()] } })
+
+    s.on('created', () => log.push('event'))
+
+    await s.create({ a: 1 })
+
+    expect(log).toEqual(['create', 'commit:root', 'event'])
+  })
+
+  it('rolls back and emits nothing when an after hook throws', async () => {
+    const log: string[] = []
+    const app = appWith(['s', new StubService(log)])
+    const s = app.service('s')
+    s.hooks({
+      around: { create: [withTransaction()] },
+      after: {
+        create: [
+          () => {
+            throw new Error('after-fail')
+          },
+        ],
+      },
+    })
+
+    const spy = vi.fn()
+    s.on('created', spy)
+
+    await expect(s.create({ a: 1 })).rejects.toThrow('after-fail')
+
+    expect(log).toEqual(['create', 'rollback:root'])
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('rolls back when the method itself throws', async () => {
+    const log: string[] = []
+    const stub = new StubService(log)
+    stub.failCreate = true
+    const app = appWith(['s', stub])
+    const s = app.service('s')
+    s.hooks({ around: { create: [withTransaction()] } })
+
+    const spy = vi.fn()
+    s.on('created', spy)
+
+    await expect(s.create({ a: 1 })).rejects.toThrow('create failed')
+
+    expect(log).toEqual(['create', 'rollback:root'])
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('defers nested cross-service events until the root commits', async () => {
+    const log: string[] = []
+    const a = new StubService(log)
+    const b = new StubService(log)
+    const app = appWith(['a', a], ['b', b])
+    const aSvc = app.service('a')
+    const bSvc = app.service('b')
+
+    a.onCreate = async (_data, params) => {
+      await (app.service('b') as any).create(
+        { x: 1 },
+        { transaction: params.transaction },
+      )
+    }
+
+    aSvc.hooks({ around: { create: [withTransaction()] } })
+    bSvc.hooks({ around: { create: [withTransaction()] } })
+
+    aSvc.on('created', () => log.push('event:a'))
+    bSvc.on('created', () => log.push('event:b'))
+
+    await aSvc.create({ a: 1 })
+
+    // b runs first (savepoint), a commits root, then queue flushes b then a
+    expect(log).toEqual([
+      'create', // a.create begins, calls b
+      'create', // b.create
+      'commit:root>sp', // b's savepoint commit
+      'commit:root', // a's root commit
+      'event:b', // flushed in push order (b captured first)
+      'event:a',
+    ])
+  })
+
+  it('discards nested cross-service events when the root rolls back', async () => {
+    const log: string[] = []
+    const a = new StubService(log)
+    const b = new StubService(log)
+    const app = appWith(['a', a], ['b', b])
+    const aSvc = app.service('a')
+    const bSvc = app.service('b')
+
+    a.onCreate = async (_data, params) => {
+      await (app.service('b') as any).create(
+        { x: 1 },
+        { transaction: params.transaction },
+      )
+    }
+
+    aSvc.hooks({
+      around: { create: [withTransaction()] },
+      after: {
+        create: [
+          () => {
+            throw new Error('nope')
+          },
+        ],
+      },
+    })
+    bSvc.hooks({ around: { create: [withTransaction()] } })
+
+    const spyA = vi.fn()
+    const spyB = vi.fn()
+    aSvc.on('created', spyA)
+    bSvc.on('created', spyB)
+
+    await expect(aSvc.create({ a: 1 })).rejects.toThrow('nope')
+
+    expect(spyA).not.toHaveBeenCalled()
+    expect(spyB).not.toHaveBeenCalled()
+    expect(log).toEqual([
+      'create',
+      'create',
+      'commit:root>sp', // b's savepoint committed
+      'rollback:root', // a rolls back the root => everything discarded
+    ])
+  })
+
+  it('handles three levels of nesting (a -> b -> c)', async () => {
+    const log: string[] = []
+    const a = new StubService(log)
+    const b = new StubService(log)
+    const c = new StubService(log)
+    const app = appWith(['a', a], ['b', b], ['c', c])
+    const aSvc = app.service('a')
+    const bSvc = app.service('b')
+    const cSvc = app.service('c')
+
+    a.onCreate = async (_d, params) => {
+      await (app.service('b') as any).create(
+        { n: 1 },
+        { transaction: params.transaction },
+      )
+    }
+    b.onCreate = async (_d, params) => {
+      await (app.service('c') as any).create(
+        { n: 1 },
+        { transaction: params.transaction },
+      )
+    }
+
+    aSvc.hooks({ around: { create: [withTransaction()] } })
+    bSvc.hooks({ around: { create: [withTransaction()] } })
+    cSvc.hooks({ around: { create: [withTransaction()] } })
+
+    aSvc.on('created', () => log.push('event:a'))
+    bSvc.on('created', () => log.push('event:b'))
+    cSvc.on('created', () => log.push('event:c'))
+
+    await aSvc.create({})
+
+    // only the root (a) flushes; innermost captured first
+    expect(log.slice(-3)).toEqual(['event:c', 'event:b', 'event:a'])
+    expect(log).toContain('commit:root')
+    expect(log.indexOf('commit:root')).toBeLessThan(log.indexOf('event:c'))
+  })
+
+  it('handles recursive same-service calls within the transaction', async () => {
+    const log: string[] = []
+    const stub = new StubService(log)
+    const app = appWith(['s', stub])
+    const s = app.service('s')
+
+    stub.onCreate = async (data, params) => {
+      if (data?.depth) return
+      await (app.service('s') as any).create(
+        { depth: 1 },
+        { transaction: params.transaction },
+      )
+    }
+
+    s.hooks({ around: { create: [withTransaction()] } })
+
+    const spy = vi.fn()
+    s.on('created', spy)
+
+    await s.create({ depth: 0 })
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    // both emitted after the root commit
+    expect(log.filter((l) => l === 'commit:root')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
This pull request introduces a major improvement to how database transactions and Feathers service event emission are handled when using Kysely in Feathers apps. The new `withTransaction()` around hook provides robust, automatic transaction management and ensures that service events are only emitted after a successful commit, preventing listeners from reacting to rolled-back changes. The documentation is updated to recommend this approach, and the implementation now supports deferral of events—including those from nested, cross-service calls—until the root transaction commits. Legacy hooks are retained for backward compatibility but are now deprecated.

**Transaction/event management improvements:**

* Introduced the `withTransaction()` around hook, which automatically wraps service calls in a Kysely transaction, defers Feathers service events until the transaction commits, and supports nested transactions via savepoints. This ensures that events from both root and nested service calls are only emitted on successful commit and discarded on rollback.
* Updated the `KyselyAdapterTransaction` interface to include a `savepoint` property for nested transaction savepoints and a `deferredEvents` queue for event deferral.
* Refactored transaction start/commit/rollback logic to handle savepoints for nested transactions, and to flush or discard deferred events based on transaction outcome.

**Documentation updates:**

* Thoroughly revised the `docs/api/transactions.md` to recommend `withTransaction()` as the preferred transaction management method, document event deferral semantics, and clarify usage for nested and cross-service transactions. Legacy hooks are now marked as deprecated. [[1]](diffhunk://#diff-c53ca83ea782ac8652ca3ecb8c01042a483e91a20cb75bbc6294c62b034f8a0bL3-R89) [[2]](diffhunk://#diff-c53ca83ea782ac8652ca3ecb8c01042a483e91a20cb75bbc6294c62b034f8a0bL25-R112) [[3]](diffhunk://#diff-c53ca83ea782ac8652ca3ecb8c01042a483e91a20cb75bbc6294c62b034f8a0bL54-R145)

**Exports:**

* Added `withTransaction` to the public exports for use in application code.

These changes ensure safer, more predictable event emission in transactional workflows and modernize the recommended approach for transaction management in Feathers-Kysely apps.