### PR TITLE
fix: security bugs perf hardening

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,9 @@
       "Bash(pnpm lint *)",
       "Bash(pnpm docs:build)",
       "Bash(pnpm view *)",
-      "Bash(DB=sqlite pnpm vitest run)"
+      "Bash(DB=sqlite pnpm vitest run)",
+      "Bash(pnpm exec *)",
+      "Bash(echo \"=== tsc exit: $? ===\")"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > A [FeathersJS](https://feathersjs.com/) database adapter for [Kysely](https://kysely.dev/) — the type-safe SQL query builder.
 
-Supports **PostgreSQL**, **MySQL**, **SQLite**, and **MSSQL**.
+Supports **PostgreSQL**, **MySQL**, and **SQLite**.
 
 ## Installation
 

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -21,7 +21,7 @@ All standard [Feathers query operators](https://feathersjs.com/api/databases/que
 | ------------ | --------------- | ---------------------------------------------- |
 | `$like`      | `LIKE`          | Pattern matching                               |
 | `$notLike`   | `NOT LIKE`      | Negated pattern matching                       |
-| `$iLike`     | `ILIKE`         | Case-insensitive pattern matching (PostgreSQL) |
+| `$iLike`     | `ILIKE` / `LIKE`| Case-insensitive pattern matching (Postgres uses `ILIKE`; MySQL/SQLite fall back to `LIKE`, which is case-insensitive for ASCII) |
 
 ## Array Operators (PostgreSQL)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hero:
     alt: feathers-kysely logo
   name: feathers-kysely
   text: Type-safe SQL for FeathersJS
-  tagline: A database adapter for Kysely — the type-safe SQL query builder. Supports PostgreSQL, MySQL, SQLite, and MSSQL.
+  tagline: A database adapter for Kysely — the type-safe SQL query builder. Supports PostgreSQL, MySQL, and SQLite.
   actions:
     - theme: brand
       text: Get Started
@@ -24,5 +24,5 @@ features:
   - title: Transactions
     details: Full transaction support with hooks or manual control, including nested savepoints.
   - title: Multi-dialect
-    details: Works with PostgreSQL, MySQL, SQLite, and MSSQL out of the box.
+    details: Works with PostgreSQL, MySQL, and SQLite out of the box.
 ---

--- a/package.json
+++ b/package.json
@@ -17,19 +17,16 @@
   },
   "contributors": [],
   "bugs": {
-    "url": "https://github.com/marshallswain/feathers-kysely/issues"
+    "url": "https://github.com/fratzinger/feathers-kysely/issues"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "files": [
     "CHANGELOG.md",
     "LICENSE",
     "README.md",
-    "src/**",
-    "dist/**",
-    "*.d.ts",
-    "*.js"
+    "dist"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -38,13 +35,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsdown",
     "version": "pnpm build",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "lint": "eslint",
     "vitest": "vitest",
     "docs:dev": "vitepress dev docs",
@@ -82,7 +81,7 @@
   },
   "peerDependencies": {
     "@feathersjs/feathers": "^5.0.0",
-    "kysely": "^0.28.0"
+    "kysely": ">=0.28.0 <0.30.0"
   },
   "packageManager": "pnpm@11.1.2",
   "pnpm": {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -12,7 +12,12 @@ import type {
   AdapterQuery,
 } from '@feathersjs/adapter-commons'
 import { AdapterBase, getLimit } from '@feathersjs/adapter-commons'
-import { BadRequest, MethodNotAllowed, NotFound } from '@feathersjs/errors'
+import {
+  BadRequest,
+  GeneralError,
+  MethodNotAllowed,
+  NotFound,
+} from '@feathersjs/errors'
 
 import { errorHandler } from './error-handler.js'
 import type {
@@ -32,7 +37,7 @@ import type {
   SelectQueryBuilder,
   UpdateQueryBuilder,
   ExpressionBuilder,
-  ExpressionWrapper,
+  Expression,
 } from 'kysely'
 import {
   applySelectId,
@@ -61,7 +66,32 @@ const OPERATORS: Record<string, ComparisonOperatorExpression> = {
   $overlap: '&&',
 }
 
+// Operators that only exist in Postgres. They are not registered (and therefore
+// rejected by Feathers with a BadRequest) on other dialects. NOTE: $iLike is
+// intentionally NOT here — it is translated to a case-insensitive LIKE instead.
+const POSTGRES_ONLY_OPERATORS = ['$contains', '$contained', '$overlap']
+
+function getDatabaseDialect(db: Kysely<any>): DialectType {
+  const adapterName = db.getExecutor().adapter.constructor.name.toLowerCase()
+
+  if (adapterName.includes('sqlite')) return 'sqlite'
+  if (adapterName.includes('postgres')) return 'postgres'
+  if (adapterName.includes('mysql')) return 'mysql'
+  if (adapterName.includes('mssql') || adapterName.includes('sqlserver')) {
+    throw new Error(
+      'MSSQL is not supported by feathers-kysely. Supported dialects: postgres, mysql, sqlite.',
+    )
+  }
+
+  return 'sqlite'
+}
+
 // TODO: $between, $notBetween
+
+// Alias for the window-count column injected into the data query so a paginated
+// find can return rows and the grand total in a single round-trip. Stripped
+// from every row before the result is returned.
+const PAGINATION_TOTAL_KEY = '__fk_total'
 
 const FILTERS = ['$select', '$sort', '$limit', '$skip'] as const
 type Filter = (typeof FILTERS)[number]
@@ -131,6 +161,8 @@ export class KyselyAdapter<
       throw new Error('No table name specified.')
     }
 
+    const dialectType = options.dialectType ?? getDatabaseDialect(options.Model)
+
     super({
       id: 'id',
       ...options,
@@ -141,15 +173,19 @@ export class KyselyAdapter<
       operators: [
         ...new Set([
           ...(options.operators ?? []),
-          ...Object.keys(OPERATORS),
+          // Don't register Postgres-only operators on other dialects so Feathers
+          // rejects them with a BadRequest instead of producing invalid SQL.
+          ...Object.keys(OPERATORS).filter(
+            (op) =>
+              dialectType === 'postgres' ||
+              !POSTGRES_ONLY_OPERATORS.includes(op),
+          ),
           '$none',
           '$some',
           '$every',
         ]),
       ],
     })
-
-    const dialectType = this.getDatabaseDialect(options.Model)
 
     this.options.dialectType ??= dialectType
     this.propertyMap = new Map<string, any>(
@@ -163,20 +199,6 @@ export class KyselyAdapter<
 
   async setup(app: any, _path: string) {
     this.app ??= app
-  }
-
-  private getDatabaseDialect(db?: Kysely<any>): DialectType {
-    const adapterName = (db ?? this.Model)
-      .getExecutor()
-      .adapter.constructor.name.toLowerCase()
-
-    if (adapterName.includes('sqlite')) return 'sqlite'
-    if (adapterName.includes('postgres')) return 'postgres'
-    if (adapterName.includes('mysql')) return 'mysql'
-    if (adapterName.includes('mssql') || adapterName.includes('sqlserver'))
-      return 'mssql'
-
-    return 'sqlite'
   }
 
   get Model() {
@@ -214,17 +236,28 @@ export class KyselyAdapter<
       $select: _select,
       $sort,
       $limit: _limit,
-      $skip = 0,
+      $skip: _skip = 0,
       ...query
     } = (params.query || {}) as AdapterQuery
+
+    // A negative $skip is invalid; floor it to 0 so it never reaches OFFSET.
+    const $skip = typeof _skip === 'number' && _skip > 0 ? _skip : 0
+
+    // getLimit only clamps the upper bound — floor negative client-supplied
+    // limits to 0 (a negative LIMIT errors on Postgres/MySQL). The sqlite/mysql
+    // "no limit" sentinels below are only reached when no limit was given.
+    const baseLimit = getLimit(_limit, options.paginate)
+    const clampedLimit =
+      typeof baseLimit === 'number' && baseLimit < 0 ? 0 : baseLimit
+
     const $limit = $skip
-      ? (getLimit(_limit, options.paginate) ??
+      ? (clampedLimit ??
         (options.dialectType === 'sqlite'
           ? -1
           : options.dialectType === 'mysql'
             ? 4294967295 /** max value for mysql */
             : undefined))
-      : getLimit(_limit, options.paginate)
+      : clampedLimit
 
     const $select = applySelectId(_select, options.id)
 
@@ -293,6 +326,17 @@ export class KyselyAdapter<
 
     if (options?.order) {
       q = this.applySort(q, filters)
+
+      // When a result window (LIMIT/OFFSET) is in effect but the caller gave no
+      // $sort, append the primary key as a deterministic tiebreaker. Without it,
+      // OFFSET pagination can return overlapping or missing rows across pages.
+      const hasSort = !!filters.$sort && Object.keys(filters.$sort).length > 0
+      const windowed =
+        (typeof filters.$limit === 'number' && filters.$limit > 0) ||
+        (typeof filters.$skip === 'number' && filters.$skip > 0)
+      if (!hasSort && windowed) {
+        q = (q as any).orderBy(this.col(this.options.id), 'asc')
+      }
     }
 
     return q
@@ -577,7 +621,7 @@ export class KyselyAdapter<
     filterQuery: Record<string, any>,
     operator: '$some' | '$none' | '$every' = '$some',
   ) {
-    const subQueries: ExpressionWrapper<any, any, any>[] = []
+    const subQueries: Expression<any>[] = []
 
     for (const subKey in filterQuery) {
       const subQuery = this.handleQueryProperty(
@@ -656,7 +700,7 @@ export class KyselyAdapter<
     }
 
     if (nested) {
-      const results: ExpressionWrapper<any, any, any>[] = []
+      const results: Expression<any>[] = []
 
       // Separate collection operators ($none, $some, $every) from regular filters
       const regularFilters: Record<string, any> = {}
@@ -694,7 +738,7 @@ export class KyselyAdapter<
     }
 
     // Dot notation: always behaves as $some (backward-compatible)
-    const subQueries: ExpressionWrapper<any, any, any>[] = []
+    const subQueries: Expression<any>[] = []
     const nestedWhere = this.handleQueryPropertyNormal(
       eb,
       queryKey,
@@ -760,7 +804,7 @@ export class KyselyAdapter<
       return
     }
 
-    const subQueries: ExpressionWrapper<any, any, any>[] = []
+    const subQueries: Expression<any>[] = []
     for (const subKey in queryProperty) {
       const subQuery = this.handleQueryProperty(
         eb,
@@ -794,7 +838,11 @@ export class KyselyAdapter<
       return
     }
 
-    const column = traverseJSON(eb, this.col(parts[0]), parts.slice(1))
+    const column = traverseJSON(
+      this.col(parts[0]),
+      parts.slice(1),
+      this.options.dialectType,
+    )
 
     return this.buildPropertyExpression(eb, column, queryProperty)
   }
@@ -846,6 +894,14 @@ export class KyselyAdapter<
     options?: HandleQueryOptions,
   ) {
     if (queryKey === '$and' || queryKey === '$or') {
+      // Explicit boolean-identity semantics for an empty operand: an empty `$and`
+      // matches everything (1 = 1), an empty `$or` matches nothing (1 = 0). This
+      // prevents an authorization hook that injects `$or: []` (e.g. derived from
+      // an empty list of permitted scopes) from silently matching all rows.
+      if (Array.isArray(queryProperty) && queryProperty.length === 0) {
+        return queryKey === '$and' ? sql<boolean>`1 = 1` : sql<boolean>`1 = 0`
+      }
+
       const method = eb[queryKey === '$and' ? 'and' : 'or']
       const subs = []
       for (const subQuery of queryProperty) {
@@ -896,12 +952,20 @@ export class KyselyAdapter<
   }
 
   private getOperator(op: string, value: any) {
-    if (value !== null) {
+    if (value === null) {
+      if (op === '$ne') return 'is not'
+      if (op === '$eq') return 'is'
       return OPERATORS[op]
     }
 
-    if (op === '$ne') return 'is not'
-    if (op === '$eq') return 'is'
+    // No dialect except Postgres has an ILIKE keyword. MySQL's default collation
+    // is case-insensitive and SQLite's LIKE is case-insensitive for ASCII, so
+    // plain LIKE gives equivalent behavior for typical input (case folding of
+    // non-ASCII on SQLite/MySQL depends on the column collation).
+    if (op === '$iLike' && this.options.dialectType !== 'postgres') {
+      return 'like'
+    }
+
     return OPERATORS[op]
   }
 
@@ -918,14 +982,14 @@ export class KyselyAdapter<
       throw new BadRequest(`The value for '${op}' must be an array`)
     }
 
-    // For PostgreSQL, we need to help with type inference
-    // Cast based on the first element's type
+    // These are the Postgres array operators (@>, <@, &&). Build a properly
+    // typed array literal with every element bound as a parameter, casting
+    // based on the first element's type so Postgres can infer the array type.
     const firstElement = value[0]
     if (typeof firstElement === 'number') {
       return sql`ARRAY[${sql.join(value)}]::integer[]`
     } else if (typeof firstElement === 'string') {
-      return sql`${JSON.stringify(value)}`
-      //return sql`ARRAY[${sql.join(value)}]::varchar[]`
+      return sql`ARRAY[${sql.join(value)}]::text[]`
     } else {
       // Default case - let PostgreSQL try to infer
       return sql`ARRAY[${sql.join(value)}]`
@@ -1156,27 +1220,59 @@ export class KyselyAdapter<
     })
 
     if (paginate && paginate.default) {
-      const countQuery = this.composeQuery(params, {
-        select: [
-          this.db(params).fn.count(this.col(this.options.id)).as('total'),
-        ],
-        where: true,
-      })
+      const runCountQuery = () =>
+        this.composeQuery(params, {
+          select: [
+            this.db(params).fn.count(this.col(this.options.id)).as('total'),
+          ],
+          where: true,
+        })
+          .executeTakeFirst()
+          .catch(errorHandler)
 
-      const [queryResult, countQueryResult] = await Promise.all([
-        filters.$limit !== 0 ? q.execute().catch(errorHandler) : undefined,
-        countQuery.executeTakeFirst().catch(errorHandler),
-      ])
-
-      const data = filters.$limit === 0 ? [] : queryResult
-      const total = Number((countQueryResult as any)?.total ?? 0) || 0
-
-      return {
-        total,
+      const buildResult = (total: any, data: Result[]): Paginated<Result> => ({
+        total: Number((total as any)?.total ?? total ?? 0) || 0,
         limit: filters.$limit!,
         skip: filters.$skip || 0,
-        data: data as Result[],
+        data,
+      })
+
+      // Count-only request ($limit === 0): skip the data query entirely.
+      if (filters.$limit === 0) {
+        return buildResult(await runCountQuery(), [])
       }
+
+      const { dialectType } = this.options
+
+      // Postgres & SQLite: fetch the rows and the grand total in a single
+      // round-trip via a window count. Window functions are evaluated over the
+      // full filtered set before LIMIT/OFFSET, so the total is correct even when
+      // a page is requested. Fall back to a separate count only when the page is
+      // empty (e.g. $skip past the end), where no row carries the total.
+      if (dialectType === 'postgres' || dialectType === 'sqlite') {
+        const rows = (await (q as any)
+          .select(sql`count(*) over()`.as(PAGINATION_TOTAL_KEY))
+          .execute()
+          .catch(errorHandler)) as any[]
+
+        if (rows.length > 0) {
+          const total = Number(rows[0][PAGINATION_TOTAL_KEY] ?? 0) || 0
+          for (const row of rows) {
+            delete row[PAGINATION_TOTAL_KEY]
+          }
+          return buildResult(total, rows as Result[])
+        }
+
+        return buildResult(await runCountQuery(), [])
+      }
+
+      // Other dialects: run the data and count queries in parallel.
+      const [queryResult, countQueryResult] = await Promise.all([
+        q.execute().catch(errorHandler),
+        runCountQuery(),
+      ])
+
+      return buildResult(countQueryResult, queryResult as Result[])
     }
 
     const data =
@@ -1218,6 +1314,11 @@ export class KyselyAdapter<
       options: KyselyAdapterOptionsDefined
       params: ServiceParams
       $select?: string[]
+      /**
+       * The original input data, used (MySQL only) to recover explicitly
+       * supplied primary keys when re-fetching the written rows.
+       */
+      data?: any
       buildWhere?: (
         query: SelectQueryBuilder<any, any, any>,
       ) => SelectQueryBuilder<any, any, any>
@@ -1249,12 +1350,49 @@ export class KyselyAdapter<
         : query.executeTakeFirst().catch(errorHandler)
     }
 
-    // Standard insert logic (build WHERE based on insertId)
-    const { insertId, numInsertedOrUpdatedRows } = response as any
-    const id = Number(insertId)
-    const count = Number(numInsertedOrUpdatedRows)
+    // Standard insert logic: figure out which rows to re-fetch. MySQL has no
+    // RETURNING, so we identify the written rows by their primary key.
+    const rows: any[] = isArray
+      ? Array.isArray(context.data)
+        ? context.data
+        : []
+      : context.data != null
+        ? [context.data]
+        : []
 
-    const ids = isArray ? [...Array(count).keys()].map((i) => id + i) : [id]
+    const suppliedIds = rows
+      .map((row) => (row == null ? undefined : row[idField]))
+      .filter((value) => value !== undefined && value !== null)
+
+    let ids: any[]
+    if (suppliedIds.length > 0 && suppliedIds.length === rows.length) {
+      // Every inserted row carried an explicit primary key (e.g. UUID or
+      // application-assigned id) — re-fetch by those, never by guessing.
+      ids = suppliedIds
+    } else {
+      // Fall back to MySQL's auto-increment block, which starts at insertId and
+      // is contiguous for a single multi-row INSERT. Guard against a missing /
+      // non-numeric insertId (e.g. a non-auto-increment key with no value).
+      const { insertId, numInsertedOrUpdatedRows } = response as any
+      const firstId = Number(insertId)
+      const count = Number(numInsertedOrUpdatedRows ?? 1)
+
+      if (
+        !Number.isFinite(firstId) ||
+        firstId <= 0 ||
+        !Number.isFinite(count) ||
+        count <= 0
+      ) {
+        throw new GeneralError(
+          'Unable to determine the id(s) of the inserted MySQL row(s). ' +
+            'Provide an explicit id in the data, or use a dialect that supports RETURNING.',
+        )
+      }
+
+      ids = isArray
+        ? Array.from({ length: count }, (_, i) => firstId + i)
+        : [firstId]
+    }
 
     const where =
       ids.length === 1
@@ -1491,6 +1629,7 @@ export class KyselyAdapter<
       options,
       params,
       $select,
+      data: _data,
     })
 
     return response
@@ -1552,6 +1691,7 @@ export class KyselyAdapter<
       options,
       params,
       $select,
+      data: _data,
       buildWhere:
         dialectType === 'mysql' && onConflictFields.length > 0
           ? (selected) =>
@@ -1601,36 +1741,39 @@ export class KyselyAdapter<
               $select && Array.isArray($select) ? this.col($select) : $select
             const selected = select ? from.select(select) : from.selectAll(name)
 
-            // Build OR conditions for each conflict field combination
-            const missingRecords: Result[] = []
-            for (const item of dataArray) {
-              // Check if this item is already in the response
-              const isInResponse = responseArray.some((r) =>
-                onConflictFields.every((field) => {
-                  const rVal = r[field as keyof Result]
-                  const itemVal = item[field as keyof Data]
-                  return rVal === (itemVal as any)
-                }),
+            const matchesConflict = (row: any, item: any) =>
+              onConflictFields.every(
+                (field) =>
+                  row[field as keyof Result] ===
+                  (item[field as keyof Data] as any),
               )
 
-              if (!isInResponse) {
-                // Fetch the existing record
-                let query = selected
-                for (const field of onConflictFields) {
-                  query = query.where(
-                    this.col(field as string),
-                    '=',
-                    item[field as keyof Data],
-                  ) as any
-                }
-                const existing = await query
-                  .executeTakeFirst()
-                  .catch(errorHandler)
-                if (existing) {
-                  missingRecords.push(existing as Result)
-                }
-              }
+            // Items that were ignored (already existed) and thus not returned.
+            const missingItems = dataArray.filter(
+              (item) => !responseArray.some((r) => matchesConflict(r, item)),
+            )
+
+            if (missingItems.length === 0) {
+              return responseArray
             }
+
+            // Fetch all missing rows in a SINGLE round-trip (one OR-of-ANDs
+            // SELECT) instead of one SELECT per item.
+            const existingRows = (await this.buildWhereForConflictFields(
+              selected,
+              missingItems,
+              onConflictFields,
+              true,
+            )
+              .execute()
+              .catch(errorHandler)) as Result[]
+
+            // Re-order to follow the input order and drop any not found.
+            const missingRecords = missingItems
+              .map((item) =>
+                existingRows.find((row) => matchesConflict(row, item)),
+              )
+              .filter((row): row is Result => !!row)
 
             return [...responseArray, ...missingRecords] as Result[]
           }
@@ -1824,15 +1967,26 @@ export class KyselyAdapter<
     }
 
     const data = _.omit(_data, this.id)
+
+    // Replacing a record nulls out every column absent from `data`, so we need
+    // the full set of column names. When `properties` is configured (the same
+    // map col() treats as the known columns) we read only the id for the
+    // existence check; otherwise we fall back to reading the whole row.
+    const knownColumns =
+      this.propertyMap.size > 0 ? [...this.propertyMap.keys()] : undefined
+
     const oldData = await this._get(id, {
       ...params,
       query: {
         ...params.query,
-        $select: undefined,
+        $select: knownColumns ? [this.id] : undefined,
       },
     })
+
+    const columns = knownColumns ?? Object.keys(oldData)
+
     // New data changes all fields except id
-    const newObject = Object.keys(oldData).reduce((result: any, key) => {
+    const newObject = columns.reduce((result: any, key) => {
       if (key !== this.id) {
         result[key] = data[key] === undefined ? null : data[key]
       }

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -5,7 +5,7 @@ import type {
 } from '@feathersjs/adapter-commons'
 import type { ControlledTransaction, Kysely } from 'kysely'
 
-export type DialectType = 'mysql' | 'postgres' | 'sqlite' | 'mssql'
+export type DialectType = 'mysql' | 'postgres' | 'sqlite'
 
 export type Relation = {
   service: string

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -14,7 +14,11 @@ export const ERROR = Symbol.for('feathers-kysely/error')
  * Convert a database error into a Feathers error.
  */
 export function errorHandler(error: any): never {
-  const { message } = error
+  // `message` is the text surfaced to API clients. It is mutable because the
+  // Postgres branch below strips the query fragment from it before it is used
+  // to construct the Feathers error (the raw error is still preserved on
+  // `feathersError[ERROR]` for server-side logging).
+  let { message } = error
   let feathersError = error
 
   if (error.sqlState && error.sqlState.length) {
@@ -79,10 +83,11 @@ export function errorHandler(error: any): never {
   ) {
     // NOTE: Error codes taken from
     // https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html
-    // Omit query information
+    // Omit query information from the client-facing message (the raw message
+    // remains available on feathersError[ERROR]).
     const messages = (error.message || '').split('-')
 
-    error.message = messages[messages.length - 1]
+    message = messages[messages.length - 1].trim()
 
     switch (error.code.slice(0, 2)) {
       case '22':

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -76,24 +76,29 @@ const commitTransaction = async (
 ): Promise<void> => {
   const { trx, id, savepoint } = transaction
 
-  if (savepoint) {
-    await (trx as any).releaseSavepoint(savepoint).execute()
-  } else {
-    await trx.commit().execute()
+  try {
+    if (savepoint) {
+      await (trx as any).releaseSavepoint(savepoint).execute()
+    } else {
+      await trx.commit().execute()
+    }
+  } catch (error) {
+    // A failing COMMIT / RELEASE SAVEPOINT must still release anything awaiting
+    // `transaction.committed`, otherwise those awaiters hang forever.
+    if (transaction.resolve) {
+      transaction.resolve(false)
+    }
+    throw error
   }
 
   if (transaction.resolve) {
     transaction.resolve(true)
   }
 
-  // Only the root flushes the shared deferred-event queue.
-  if (!transaction.parent && transaction.deferredEvents) {
-    const queue = transaction.deferredEvents
-    transaction.deferredEvents = []
-    for (const emit of queue) {
-      emit()
-    }
-  }
+  // NOTE: deferred events are intentionally NOT flushed here. The caller flushes
+  // them after the commit succeeds (see flushDeferredEvents), so that a throwing
+  // event listener cannot bubble up and trigger a rollback of an already
+  // committed transaction.
 
   debug('ended transaction %s', id)
 }
@@ -103,22 +108,49 @@ const rollbackTransaction = async (
 ): Promise<void> => {
   const { trx, id, savepoint } = transaction
 
-  if (savepoint) {
-    await (trx as any).rollbackToSavepoint(savepoint).execute()
-  } else {
-    await trx.rollback().execute()
-  }
+  try {
+    if (savepoint) {
+      await (trx as any).rollbackToSavepoint(savepoint).execute()
+    } else {
+      await trx.rollback().execute()
+    }
+  } finally {
+    // Always release awaiters and discard deferred events, even if the
+    // rollback statement itself fails.
+    if (transaction.resolve) {
+      transaction.resolve(false)
+    }
 
-  if (transaction.resolve) {
-    transaction.resolve(false)
-  }
-
-  // Only the root owns the queue; discard everything that was deferred.
-  if (!transaction.parent && transaction.deferredEvents) {
-    transaction.deferredEvents.length = 0
+    // Only the root owns the queue; discard everything that was deferred.
+    if (!transaction.parent && transaction.deferredEvents) {
+      transaction.deferredEvents.length = 0
+    }
   }
 
   debug('rolled back transaction %s', id)
+}
+
+/**
+ * Flush the root transaction's deferred Feathers events after a successful
+ * commit. Each emitter is isolated so a throwing listener can neither abort the
+ * remaining events nor bubble up and roll back the already-committed
+ * transaction. No-op for nested (savepoint) transactions and for legacy
+ * transactions that never deferred events.
+ */
+const flushDeferredEvents = (transaction: KyselyAdapterTransaction): void => {
+  if (transaction.parent || !transaction.deferredEvents) {
+    return
+  }
+
+  const queue = transaction.deferredEvents
+  transaction.deferredEvents = []
+  for (const emit of queue) {
+    try {
+      emit()
+    } catch (error) {
+      debug('deferred event listener threw %o', error)
+    }
+  }
 }
 
 /**
@@ -246,4 +278,8 @@ export const withTransaction =
         context.params = { ...context.params, transaction: parent }
       }
     }
+
+    // Reached only on the success path (the catch above rethrows). Emit the
+    // deferred events now that the (root) transaction is durably committed.
+    flushDeferredEvents(transaction)
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,10 @@
 import { sql } from 'kysely'
+import type { OrderByItemBuilder } from 'kysely'
 import type {
-  OrderByItemBuilder,
-  ExpressionBuilder,
-  StringReference,
-} from 'kysely'
-import type { SortDirection, SortProperty } from './declarations.js'
+  DialectType,
+  SortDirection,
+  SortProperty,
+} from './declarations.js'
 import { Unprocessable } from '@feathersjs/errors'
 
 export function applySelectId($select: string[] | undefined, idField: string) {
@@ -12,25 +12,35 @@ export function applySelectId($select: string[] | undefined, idField: string) {
   return $select.includes(idField) ? $select : $select.concat(idField)
 }
 
-export function traverseJSON<DB, TB extends keyof DB>(
-  eb: ExpressionBuilder<DB, TB>,
-  column: StringReference<DB, TB>,
+/**
+ * Build a JSON-path accessor expression for a column.
+ *
+ * Every path segment is bound as a SQL parameter (never interpolated as raw
+ * SQL), so attacker-controlled query keys cannot inject SQL. The accessor is
+ * dialect-specific: Postgres uses the native `->` / `->>` operators, while
+ * SQLite and MySQL use `json_extract(col, '$.a.b')`.
+ */
+export function traverseJSON(
+  column: string,
   path: string[],
+  dialectType: DialectType = 'postgres',
 ) {
   if (!path.length) {
     throw new Unprocessable('Path must have at least one element')
   }
 
-  const accessor = path
-    .slice(0, -1)
-    .map((p) => `'${p}'`)
-    .join('->')
-  const finalKey = path[path.length - 1]
-
-  if (accessor) {
-    return sql`${sql.ref(column)}->${sql.raw(accessor)}->>'${sql.raw(finalKey)}'`
+  if (dialectType === 'sqlite' || dialectType === 'mysql') {
+    // The whole path is passed as a single bound parameter to json_extract.
+    const jsonPath = `$${path.map((p) => `.${p}`).join('')}`
+    return sql`json_extract(${sql.ref(column)}, ${jsonPath})`
   }
-  return sql`${sql.ref(column)}->>'${sql.raw(finalKey)}'`
+
+  // Postgres: col -> 'a' -> 'b' ->> 'c', each key bound as a parameter.
+  let expr = sql`${sql.ref(column)}`
+  for (const key of path.slice(0, -1)) {
+    expr = sql`${expr}->${key}`
+  }
+  return sql`${expr}->>${path[path.length - 1]}`
 }
 
 export function convertBooleansToNumbers<T>(data: T): T {

--- a/test/error-handler.test.ts
+++ b/test/error-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { errorHandler } from '../src/index.js'
+import { errorHandler, ERROR } from '../src/index.js'
 
 describe('Kysely Error handler', () => {
   it('sqlState', () => {
@@ -87,5 +87,30 @@ describe('Kysely Error handler', () => {
         name: 'GeneralError',
       },
     )
+  })
+
+  it('omits query information from the postgres client message but keeps the raw error', () => {
+    const raw = {
+      code: '23505',
+      message:
+        'Failing query: INSERT INTO users (email) VALUES ($1) - duplicate key value violates unique constraint',
+      severity: 'ERROR',
+      routine: 'exec_stmt',
+    }
+
+    try {
+      errorHandler(raw)
+      assert.fail('errorHandler should have thrown')
+    } catch (err: any) {
+      assert.strictEqual(err.name, 'BadRequest')
+      // The query fragment before the dash must not reach the client message.
+      assert.strictEqual(
+        err.message,
+        'duplicate key value violates unique constraint',
+      )
+      assert.ok(!err.message.includes('INSERT INTO users'))
+      // The original, un-stripped error is preserved for server-side logging.
+      assert.strictEqual(err[ERROR], raw)
+    }
   })
 })

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -1,0 +1,151 @@
+import type { Generated } from 'kysely'
+import { Kysely } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import dialect, { getDialect } from './dialect.js'
+
+import { KyselyService } from '../src/index.js'
+import { describe } from 'vitest'
+import { addPrimaryKey } from './test-utils.js'
+
+interface DB {
+  mysql_users: {
+    id: Generated<number>
+    name: string
+    age: number | null
+  }
+  // Non-auto-increment, application-supplied string primary key.
+  mysql_items: {
+    code: string
+    label: string | null
+  }
+}
+
+type MysqlUser = { id: number; name: string; age: number | null }
+type MysqlItem = { code: string; label: string | null }
+
+function setup() {
+  const db = new Kysely<DB>({ dialect: dialect() })
+
+  const clean = async () => {
+    await db.schema.dropTable('mysql_users').ifExists().execute()
+    await addPrimaryKey(
+      db.schema
+        .createTable('mysql_users')
+        .addColumn('name', 'varchar(255)', (col) => col.notNull())
+        .addColumn('age', 'integer'),
+      'id',
+    ).execute()
+
+    await db.schema.dropTable('mysql_items').ifExists().execute()
+    await db.schema
+      .createTable('mysql_items')
+      .addColumn('code', 'varchar(64)', (col) => col.primaryKey())
+      .addColumn('label', 'varchar(255)')
+      .execute()
+  }
+
+  const app = feathers<{
+    mysql_users: KyselyService<MysqlUser>
+    mysql_items: KyselyService<MysqlItem>
+  }>()
+    .use(
+      'mysql_users',
+      new KyselyService<MysqlUser>({
+        Model: db,
+        name: 'mysql_users',
+        multi: true,
+        properties: { id: true, name: true, age: true },
+      }),
+    )
+    .use(
+      'mysql_items',
+      new KyselyService<MysqlItem>({
+        Model: db,
+        id: 'code',
+        name: 'mysql_items',
+        multi: true,
+        properties: { code: true, label: true },
+      }),
+    )
+
+  return { app, db, clean }
+}
+
+const { app, db, clean } = setup()
+
+const dialectName = getDialect()
+
+// MySQL has no RETURNING, so the adapter re-fetches written rows by their id.
+// These tests guard that path (see executeAndReturn in src/adapter.ts).
+describe.skipIf(dialectName !== 'mysql')('mysql write path', () => {
+  beforeEach(clean)
+
+  afterAll(() => db.destroy())
+
+  it('create(single) returns the inserted row with its generated id', async () => {
+    const created = await app
+      .service('mysql_users')
+      .create({ name: 'Dave', age: 40 })
+
+    expect(typeof created.id).toBe('number')
+    expect(created.name).toBe('Dave')
+    expect(created.age).toBe(40)
+  })
+
+  it('create([...]) returns every inserted row (auto-increment ids)', async () => {
+    const created = await app.service('mysql_users').create([
+      { name: 'Alice', age: 30 },
+      { name: 'Bob', age: 25 },
+      { name: 'Charlie', age: 35 },
+    ])
+
+    expect(created).toHaveLength(3)
+
+    // Order of the IN(...) re-fetch is not guaranteed, so match set-wise.
+    const names = created.map((u) => u.name).sort()
+    expect(names).toEqual(['Alice', 'Bob', 'Charlie'])
+
+    // Each returned row carries a real, distinct numeric id paired with its row.
+    const ids = created.map((u) => u.id)
+    expect(ids.every((id) => typeof id === 'number')).toBe(true)
+    expect(new Set(ids).size).toBe(3)
+
+    const alice = created.find((u) => u.name === 'Alice')
+    expect(alice?.age).toBe(30)
+  })
+
+  it('create([...]) honors $select on the MySQL re-fetch', async () => {
+    const created = await app
+      .service('mysql_users')
+      .create([{ name: 'Eve', age: 22 }], { query: { $select: ['name'] } })
+
+    expect(created).toHaveLength(1)
+    expect(created[0].name).toBe('Eve')
+    // id is force-added by applySelectId so the adapter can re-fetch.
+    expect('id' in created[0]).toBe(true)
+  })
+
+  it('create([...]) with application-supplied (non-numeric) primary keys re-fetches by those keys', async () => {
+    // Non-sequential, non-numeric ids: the old "firstId + i" guess would return
+    // the wrong rows (or none). The fix re-fetches by the supplied codes.
+    const created = await app.service('mysql_items').create([
+      { code: 'z-100', label: 'first' },
+      { code: 'a-001', label: 'second' },
+    ])
+
+    expect(created).toHaveLength(2)
+
+    const byCode = Object.fromEntries(created.map((i) => [i.code, i.label]))
+    expect(byCode['z-100']).toBe('first')
+    expect(byCode['a-001']).toBe('second')
+  })
+
+  it('create(single) with an application-supplied primary key returns that row', async () => {
+    const created = await app
+      .service('mysql_items')
+      .create({ code: 'single-1', label: 'only' })
+
+    expect(created.code).toBe('single-1')
+    expect(created.label).toBe('only')
+  })
+})

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -216,4 +216,31 @@ describe.skipIf(dialectName !== 'postgres')('postgres', () => {
       expect(queried[1].jsonb).toEqual({ a: { b: { c: 3 } } })
     })
   })
+
+  describe('security', () => {
+    it('json path key injection is parameterized', async () => {
+      await app.service('postgres').create({ jsonb: { name: 'safe' } })
+
+      // A single-quote in a JSON path segment used to break out of the literal
+      // when built with sql.raw. It is now bound as a parameter, so the query
+      // runs (matching nothing) and the table is left intact.
+      const finalKeyInjection = await app.service('postgres').find({
+        query: { "jsonb.name'); DROP TABLE postgres; --": 'x' },
+        paginate: false,
+      })
+      expect(finalKeyInjection).toHaveLength(0)
+
+      // Same for an intermediate accessor segment.
+      const intermediateInjection = await app.service('postgres').find({
+        query: { "jsonb.a'; DROP TABLE postgres; --.b": 'x' },
+        paginate: false,
+      })
+      expect(intermediateInjection).toHaveLength(0)
+
+      // The table still exists and the original row is intact.
+      const all = await app.service('postgres').find({ paginate: false })
+      expect(all).toHaveLength(1)
+      expect(all[0].jsonb).toEqual({ name: 'safe' })
+    })
+  })
 })

--- a/test/query-edge-cases.test.ts
+++ b/test/query-edge-cases.test.ts
@@ -2,7 +2,7 @@ import type { Generated } from 'kysely'
 import { Kysely } from 'kysely'
 import assert from 'node:assert'
 import { feathers } from '@feathersjs/feathers'
-import dialect from './dialect.js'
+import dialect, { getDialect } from './dialect.js'
 
 import { KyselyService } from '../src/index.js'
 import { describe, it } from 'vitest'
@@ -294,6 +294,155 @@ describe('query edge cases', () => {
         () => app.service('users').patch(999_999, {}),
         (err: any) => err.name === 'NotFound',
       )
+    })
+  })
+
+  // MARK: Empty logical operators
+
+  describe('empty $or / $and', () => {
+    it('empty $or matches no rows', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+      ])
+      const result = await app
+        .service('users')
+        .find({ query: { $or: [] }, paginate: false })
+      assert.strictEqual(result.length, 0)
+    })
+
+    it('empty $and matches all rows', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+      ])
+      const result = await app
+        .service('users')
+        .find({ query: { $and: [] as any }, paginate: false })
+      assert.strictEqual(result.length, 2)
+    })
+  })
+
+  // MARK: Pagination clamping & stability
+
+  describe('pagination clamping', () => {
+    it('negative $limit does not error (clamped)', async () => {
+      await app.service('users').create({ name: 'a', age: 1 })
+      const result = await app
+        .service('users')
+        .find({ query: { $limit: -5 }, paginate: false })
+      assert.ok(Array.isArray(result))
+    })
+
+    it('negative $skip does not error (clamped to 0)', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+      ])
+      const result = await app.service('users').find({
+        query: { $skip: -3, $sort: { id: 1 } },
+        paginate: false,
+      })
+      assert.strictEqual(result.length, 2)
+    })
+
+    it('paginated find without $sort is stable via id tiebreaker', async () => {
+      await app
+        .service('users')
+        .create(
+          Array.from({ length: 5 }, (_, i) => ({ name: `n${i}`, age: i })),
+        )
+
+      const page1 = await app
+        .service('users')
+        .find({ query: { $limit: 2, $skip: 0 }, paginate: false })
+      const page2 = await app
+        .service('users')
+        .find({ query: { $limit: 2, $skip: 2 }, paginate: false })
+
+      const ids1 = page1.map((u) => u.id)
+      const ids2 = page2.map((u) => u.id)
+
+      assert.strictEqual(ids1.length, 2)
+      assert.strictEqual(ids2.length, 2)
+      // Consecutive pages must not overlap → deterministic ordering applied.
+      assert.ok(!ids1.some((id) => ids2.includes(id)))
+      assert.ok(Math.max(...ids1) < Math.min(...ids2))
+    })
+  })
+
+  // MARK: Dialect operator handling
+
+  describe('dialect operator handling', () => {
+    it('$iLike matches case-insensitively', async () => {
+      await app.service('users').create([
+        { name: 'Alice', age: 1 },
+        { name: 'BOB', age: 2 },
+      ])
+
+      const result = await app.service('users').find({
+        query: { name: { $iLike: '%alice%' } },
+        paginate: false,
+      })
+
+      assert.strictEqual(result.length, 1)
+      assert.strictEqual(result[0].name, 'Alice')
+    })
+
+    it.skipIf(getDialect() === 'postgres')(
+      '$contains is rejected with BadRequest on non-Postgres dialects',
+      async () => {
+        await assert.rejects(
+          () =>
+            app.service('users').find({
+              query: { name: { $contains: ['x'] } as any },
+              paginate: false,
+            }),
+          (err: any) => err.name === 'BadRequest',
+        )
+      },
+    )
+  })
+
+  // MARK: Window-count pagination
+
+  describe('paginated total', () => {
+    const paginated = new KyselyService<any>({
+      Model: db,
+      name: 'users',
+      paginate: { default: 10, max: 100 },
+    })
+
+    it('$skip past the end returns the real total with empty data', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+        { name: 'c', age: 3 },
+      ])
+
+      const result = (await paginated.find({ query: { $skip: 100 } })) as any
+      assert.strictEqual(result.total, 3)
+      assert.strictEqual(result.data.length, 0)
+      assert.strictEqual(result.skip, 100)
+    })
+
+    it('$select returns the correct total and strips the helper column', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+        { name: 'c', age: 3 },
+      ])
+
+      const result = (await paginated.find({
+        query: { $select: ['name'], $limit: 2 },
+      })) as any
+
+      assert.strictEqual(result.total, 3)
+      assert.strictEqual(result.data.length, 2)
+      for (const row of result.data) {
+        assert.ok(!('__fk_total' in row), 'window-count helper column leaked')
+        assert.ok('name' in row)
+      }
     })
   })
 })

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -562,6 +562,25 @@ describe('withTransaction event deferral (stubbed transaction)', () => {
     expect(log).toEqual(['create', 'commit:root', 'event'])
   })
 
+  it('a throwing event listener does not roll back a committed transaction', async () => {
+    const log: string[] = []
+    const app = appWith(['s', new StubService(log)])
+    const s = app.service('s')
+    s.hooks({ around: { create: [withTransaction()] } })
+
+    s.on('created', () => {
+      log.push('event')
+      throw new Error('listener boom')
+    })
+
+    // The transaction already committed before events are flushed, so a
+    // throwing listener must neither reject the call nor trigger a rollback.
+    await expect(s.create({ a: 1 })).resolves.toMatchObject({ id: 1 })
+
+    expect(log).toContain('commit:root')
+    expect(log).not.toContain('rollback:root')
+  })
+
   it('rolls back and emits nothing when an after hook throws', async () => {
     const log: string[] = []
     const app = appWith(['s', new StubService(log)])

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "src/**/*",
     "test/**/*",
     "vite.config.ts",
-    "tsup.config.ts",
     "docs/.vitepress/**/*"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This pull request introduces significant improvements to the `feathers-kysely` adapter, focusing on more accurate SQL dialect handling, improved pagination, stricter query validation, and enhanced documentation. The main changes include removing MSSQL support, refining operator and dialect handling for queries, and optimizing pagination queries for efficiency and accuracy.

**Dialect and Feature Support Updates:**

- MSSQL support is removed throughout the documentation, code, and configuration, clarifying that only PostgreSQL, MySQL, and SQLite are supported. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L10-R10) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L27-R27)
- The minimum required Node.js version is updated to 22, and the bug tracker URL is changed.
- The peer dependency range for `kysely` is restricted to versions `>=0.28.0 <0.30.0`.

**Operator and Query Handling Improvements:**

- Operator registration is now dialect-aware: Postgres-only operators (`$contains`, `$contained`, `$overlap`) are not available for other dialects, resulting in proper error handling for unsupported queries. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR69-R95) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR164-R165) [[3]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL144-L153)
- The `$iLike` operator now falls back to a case-insensitive `LIKE` for MySQL and SQLite, with updated documentation to explain this behavior. [[1]](diffhunk://#diff-1ab7f1f3bb8f7d4954c4969f321b3680a012e94f7704d723b74ebd1545da8bffL24-R24) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL899-R968)
- The logic for handling `$and` and `$or` with empty arrays is clarified: an empty `$and` matches everything, and an empty `$or` matches nothing, preventing accidental broad matches in authorization hooks.

**Pagination and Query Execution Enhancements:**

- Pagination is optimized for Postgres and SQLite by using window functions to fetch both data and total count in a single query, improving performance. For other dialects, data and count queries run in parallel.
- Negative `$skip` and `$limit` values are now safely clamped to zero, preventing invalid SQL and improving robustness.
- When paginating without an explicit sort, the primary key is appended as a tiebreaker to ensure stable pagination results.

**Type and Codebase Cleanups:**

- All references to `ExpressionWrapper` are replaced with `Expression` to align with Kysely's latest types and improve compatibility. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL35-R40) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL580-R624) [[3]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL659-R703) [[4]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL697-R741) [[5]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL763-R807)
- The logic for traversing JSON columns is updated to pass the dialect type, ensuring correct behavior across supported databases.
- Improved array literal construction for Postgres array operators, ensuring proper type inference and casting.

**Documentation and Configuration Updates:**

- Documentation and README are updated to accurately reflect supported dialects and operator behaviors. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L10-R10) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L27-R27) [[4]](diffhunk://#diff-1ab7f1f3bb8f7d4954c4969f321b3680a012e94f7704d723b74ebd1545da8bffL24-R24)
- `package.json` and `.claude/settings.json` are updated for improved scripts, exports, and correct file inclusion. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R46) [[2]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L12-R14)

---

**Dialect and Operator Handling:**
- Removed MSSQL support from documentation, code, and configuration, and made operator registration dialect-aware so Postgres-only operators are rejected on other dialects. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L10-R10) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L27-R27) [[4]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR69-R95) [[5]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR164-R165) [[6]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL144-L153)
- Improved `$iLike` operator handling and documentation: now falls back to case-insensitive `LIKE` on MySQL/SQLite, with clear docs. [[1]](diffhunk://#diff-1ab7f1f3bb8f7d4954c4969f321b3680a012e94f7704d723b74ebd1545da8bffL24-R24) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL899-R968)

**Pagination and Query Execution:**
- Optimized pagination for Postgres/SQLite using window functions to fetch data and total count in one query; for other dialects, runs queries in parallel.
- Clamped negative `$skip` and `$limit` values to zero, and added primary key as a tiebreaker in pagination for stable results. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL217-R260) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR329-R339)

**Query Logic and Type Handling:**
- Explicitly defined empty `$and` and `$or` behavior to prevent accidental broad matches; improved array literal construction for Postgres array operators. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR897-R904) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL921-R992)
- Replaced `ExpressionWrapper` with `Expression` throughout for better type compatibility. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL35-R40) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL580-R624) [[3]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL659-R703) [[4]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL697-R741) [[5]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL763-R807)

**Documentation and Configuration:**
- Updated documentation, README, and configuration files to reflect new dialect support, correct bugs URL, and Node.js version requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L10-R10) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L27-R27) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R29) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R46) [[6]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L12-R14)
- Adjusted peer dependency range for Kysely and improved package export structure. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L85-R84) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R46)

**Minor Enhancements:**
- Improved JSON column traversal and added MySQL-specific handling for re-fetching written rows. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL797-R845) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR1317-R1321)