### PR TITLE
feat: coerce date & add support for "x-db-type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -50,3 +50,76 @@ await app.service("users").find({
   },
 });
 ```
+
+## Querying JSON Columns
+
+Once a column is [declared as `json` or `jsonb`](./service#declaring-column-types),
+you can query into it with dot notation. Each segment after the column name is a
+key in the JSON document, and all comparison operators work on the resolved
+value:
+
+```ts
+const service = new KyselyService({
+  Model: db,
+  name: "events",
+  properties: {
+    payload: { type: "object", "x-db-type": "jsonb" },
+  },
+});
+
+// Nested path: payload -> a -> b -> c
+await service.find({ query: { "payload.a.b.c": { $gte: 2 } } });
+
+// Top-level key
+await service.find({ query: { "payload.name": "John" } });
+```
+
+Key segments are always parameterized, so they are safe against injection.
+
+## Querying Dates & Timestamps
+
+By default a date/timestamp query value is passed straight to the database
+driver, so what "works" depends on the dialect, the column type, and the value's
+JavaScript type. The combinations are inconsistent and some fail outright — for
+example an epoch-millisecond number throws on Postgres (no implicit cast), a
+`Date` instance throws on SQLite (better-sqlite3 cannot bind it), and a number
+silently matches the wrong rows on SQLite/MySQL.
+
+Opt in to **type-aware date coercion** by [declaring a column's temporal
+type](./service#declaring-column-types) — either with an `x-db-type` annotation
+in `properties` or with `getPropertyType`. The adapter then normalizes any of a
+`Date`, an ISO-8601 string, an epoch-millisecond number, or a `"YYYY-MM-DD"`
+string into the representation every supported driver compares correctly — a
+full ISO string for `timestamp` / `timestamptz` / `datetime` columns, and a
+`"YYYY-MM-DD"` string for `date` columns. With it enabled, all four formats
+return the same rows on every dialect:
+
+```ts
+const service = new KyselyService({
+  Model: db,
+  name: "events",
+  properties: {
+    startsAt: { "x-db-type": "timestamptz" },
+    day: { "x-db-type": "date" },
+  },
+});
+
+// All of these are equivalent now:
+await service.find({ query: { startsAt: { $gt: new Date("2026-01-15T10:30:00Z") } } });
+await service.find({ query: { startsAt: { $gt: "2026-01-15T10:30:00.000Z" } } });
+await service.find({ query: { startsAt: { $gt: 1768473000000 } } });
+
+// A "YYYY-MM-DD" value is the right format for a `date` column:
+await service.find({ query: { day: { $gte: "2026-01-15" } } });
+```
+
+::: tip Notes
+
+- Normalization is done in **UTC**. A `"YYYY-MM-DD"` value against a `timestamp`
+  column is interpreted as that day's UTC midnight.
+- Coercion is applied to `$lt`, `$lte`, `$gt`, `$gte`, `$eq`, `$ne`, `$in`, and
+  `$nin` values; `null` and pattern operators are left untouched.
+- It only affects **query** values. Stored values must already be in a comparable
+  format (e.g. ISO strings for SQLite text columns).
+
+:::

--- a/docs/api/service.md
+++ b/docs/api/service.md
@@ -40,5 +40,48 @@ class MyService extends KyselyAdapter {
 | `operators` | `string[]`            | —          | Additional query operators to allow    |
 | `filters`   | `object`              | —          | Additional query filters               |
 | `relations` | `object`              | —          | Relation definitions (see [Relations](../relations/setup)) |
-| `properties` | `object`             | —          | Column property definitions            |
-| `getPropertyType` | `function`       | —          | Function to resolve property types (e.g. for JSON columns) |
+| `properties` | `object`             | —          | Map of column name → JSON schema property object (typically your service's schema `properties`). Used as the set of known columns and as a declarative source for a column's database type via an [`x-db-type`](#declaring-column-types) annotation |
+| `getPropertyType` | `function`       | —          | Resolve a column's type. Returns `'json'`/`'jsonb'` for JSON columns, or a temporal type (`'date'`, `'timestamp'`, `'timestamptz'`, `'datetime'`) to enable [date coercion](./operators#querying-dates-timestamps). Takes precedence over `x-db-type` |
+
+## Declaring column types
+
+Two features need to know a column's underlying database type:
+
+- **JSON columns** — to query into a `json`/`jsonb` column with [dot notation](./operators#querying-json-columns).
+- **Temporal columns** — to enable [type-aware date coercion](./operators#querying-dates-timestamps).
+
+You can declare the type in either of two ways. The declarative `x-db-type`
+annotation lives on the column's entry in `properties` (which is typically your
+service's JSON schema `properties` block), so the type sits next to the field
+definition:
+
+```ts
+new KyselyService({
+  Model: db,
+  name: "events",
+  properties: {
+    id: true,
+    startsAt: { type: "string", format: "date-time", "x-db-type": "timestamptz" },
+    day: { type: "string", "x-db-type": "date" },
+    payload: { type: "object", "x-db-type": "jsonb" },
+  },
+});
+```
+
+The imperative `getPropertyType` function is the alternative (and escape hatch).
+It takes precedence over `x-db-type`; return `undefined` to fall back to the
+annotation:
+
+```ts
+new KyselyService({
+  Model: db,
+  name: "events",
+  getPropertyType: (property) => {
+    if (property === "startsAt") return "timestamptz";
+    if (property === "payload") return "jsonb";
+  },
+});
+```
+
+Recognized types are `'json'`, `'jsonb'`, `'date'`, `'timestamp'`,
+`'timestamptz'`, and `'datetime'`.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "node": ">= 22"
   },
   "files": [
-    "CHANGELOG.md",
     "LICENSE",
     "README.md",
     "dist"

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -41,9 +41,11 @@ import type {
 } from 'kysely'
 import {
   applySelectId,
+  coerceTemporalQueryProperty,
   convertBooleansToNumbers,
   getOrderByModifier,
   getSortDirection,
+  temporalKind,
   traverseJSON,
 } from './utils.js'
 import { addToQuery } from 'feathers-utils'
@@ -819,20 +821,38 @@ export class KyselyAdapter<
     return subQueries.length === 0 ? undefined : eb.and(subQueries)
   }
 
+  /**
+   * Resolve the database type of a column, used for JSON traversal and opt-in
+   * temporal date coercion. An explicit `getPropertyType` option wins; when it
+   * is absent (or returns `undefined`) we fall back to an `x-db-type`
+   * annotation on the column's entry in `properties` (typically the service's
+   * JSON schema `properties` block).
+   */
+  private getPropertyType(property: string): string | undefined {
+    const explicit = this.options.getPropertyType?.(property)
+    if (explicit != null) return explicit
+
+    const meta = this.propertyMap.get(property)
+    if (meta && typeof meta === 'object') {
+      const annotated = (meta as Record<string, any>)['x-db-type']
+      if (typeof annotated === 'string') return annotated
+    }
+
+    return undefined
+  }
+
   private handleJson(
     eb: ExpressionBuilder<any, any>,
     queryKey: string,
     queryProperty: any,
   ) {
-    if (!this.options.getPropertyType) return
-
     if (!queryKey.includes('.')) {
       return
     }
 
     const parts = queryKey.split('.')
 
-    const type = this.options.getPropertyType(parts[0])
+    const type = this.getPropertyType(parts[0])
 
     if (type !== 'json' && type !== 'jsonb') {
       return
@@ -915,7 +935,16 @@ export class KyselyAdapter<
 
     const col = this.col(queryKey, { tableName: options?.tableName })
 
-    return this.buildPropertyExpression(eb, col, queryProperty)
+    // Opt-in, type-aware date coercion: when the column is declared temporal
+    // (via `getPropertyType` or an `x-db-type` schema annotation), normalize
+    // Date / ISO-string / epoch-ms / "YYYY-MM-DD" query values into the
+    // canonical string the driver compares correctly.
+    const kind = temporalKind(this.getPropertyType(queryKey))
+    const property = kind
+      ? coerceTemporalQueryProperty(queryProperty, kind)
+      : queryProperty
+
+    return this.buildPropertyExpression(eb, col, property)
   }
 
   private applyJoinsForOrderBy<Q extends Record<string, any>>(

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -24,11 +24,43 @@ export interface KyselyAdapterOptions extends AdapterServiceOptions {
   dialectType?: DialectType
   // TODO
   relations?: Record<string, Relation>
-  // TODO
-  properties?: Record<string, any>
-  getPropertyType?: (
-    property: string,
-  ) => 'json' | 'jsonb' | (string & {}) | undefined
+  /**
+   * Map of column name → JSON schema property object (typically the service's
+   * schema `properties` block). Used as the set of known columns and as a
+   * declarative source for the column's database type via an `x-db-type`
+   * annotation, e.g. `{ createdAt: { type: 'string', 'x-db-type': 'timestamptz' } }`.
+   * An explicit `getPropertyType` takes precedence over `x-db-type`.
+   */
+  properties?: Record<string, PropertySchema | true>
+  /**
+   * Resolve the database type of a column. Takes precedence over an
+   * `x-db-type` annotation in `properties`; return `undefined` to fall back to
+   * the annotation (or to no special handling).
+   */
+  getPropertyType?: (property: string) => DbPropertyType | undefined
+}
+
+/**
+ * Database type of a column. `json`/`jsonb` enable dot-notation traversal into
+ * JSON columns; the temporal types enable opt-in, type-aware date coercion of
+ * query values (Date / ISO string / epoch-ms / "YYYY-MM-DD") on the column.
+ */
+export type DbPropertyType =
+  | 'json'
+  | 'jsonb'
+  | 'date'
+  | 'timestamp'
+  | 'timestamptz'
+  | 'datetime'
+  | (string & {})
+
+/**
+ * A JSON schema property object. Arbitrary keywords are allowed; `x-db-type`
+ * is read by the adapter to determine the column's database type.
+ */
+export type PropertySchema = {
+  'x-db-type'?: DbPropertyType
+  [key: string]: any
 }
 
 export interface KyselyAdapterTransaction {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,6 +93,105 @@ export function convertBooleansToNumbers<T>(data: T): T {
   return modified ? result : data
 }
 
+// Recognized temporal column kinds for opt-in date coercion. 'instant' covers
+// timestamp/timestamptz/datetime columns; 'date' is a calendar day with no time.
+export type TemporalKind = 'instant' | 'date'
+
+/**
+ * Map a `getPropertyType` return value to a temporal coercion kind, or
+ * `undefined` when the type is not a recognized temporal type (so no coercion
+ * happens). Matching is case-insensitive: anything containing "timestamp" or
+ * equal to "datetime" is an instant; an exact "date" is a calendar day.
+ */
+export function temporalKind(type: unknown): TemporalKind | undefined {
+  if (typeof type !== 'string') return undefined
+  const t = type.toLowerCase()
+  if (t === 'datetime' || t.includes('timestamp')) return 'instant'
+  if (t === 'date') return 'date'
+  return undefined
+}
+
+/**
+ * Normalize a single query value for a temporal column into the canonical
+ * string representation that every supported driver compares correctly: a full
+ * ISO-8601 UTC string for an instant column, or a "YYYY-MM-DD" string for a date
+ * column. Accepts a Date, an epoch-millisecond number, an ISO string, or a
+ * "YYYY-MM-DD" string. Normalization is done in UTC. Values that cannot be
+ * parsed into a valid date (including null) are returned unchanged.
+ */
+export function coerceTemporalValue(
+  value: unknown,
+  kind: TemporalKind,
+): unknown {
+  if (value == null) return value
+
+  let date: Date
+  if (value instanceof Date) {
+    date = value
+  } else if (typeof value === 'number' || typeof value === 'string') {
+    date = new Date(value)
+  } else {
+    return value
+  }
+
+  if (Number.isNaN(date.getTime())) return value
+
+  const iso = date.toISOString()
+  return kind === 'date' ? iso.slice(0, 10) : iso
+}
+
+// Comparison operators whose values are temporal scalars (or arrays of them).
+// Pattern operators ($like, …) and the Postgres array operators are excluded so
+// their values are never reinterpreted as dates.
+const TEMPORAL_OPERATORS = new Set([
+  '$lt',
+  '$lte',
+  '$gt',
+  '$gte',
+  '$eq',
+  '$ne',
+  '$in',
+  '$nin',
+])
+
+/**
+ * Coerce the value side of a single column's query for a temporal column. The
+ * input is either a bare value (`{ col: value }`) or an operator object
+ * (`{ col: { $gt: value, $in: [...] } }`). Operator keys and non-temporal
+ * operators are left untouched; only the leaf values of temporal comparison
+ * operators (and bare equality) are normalized via `coerceTemporalValue`.
+ */
+export function coerceTemporalQueryProperty(
+  queryProperty: any,
+  kind: TemporalKind,
+): any {
+  // An operator object like { $gt: ..., $in: [...] }. A Date is an object too,
+  // so treat only record-like objects as operator maps; a Date/array/scalar is
+  // a bare value.
+  if (
+    queryProperty !== null &&
+    typeof queryProperty === 'object' &&
+    !(queryProperty instanceof Date) &&
+    !Array.isArray(queryProperty)
+  ) {
+    const out: Record<string, any> = {}
+    for (const operator in queryProperty) {
+      const value = queryProperty[operator]
+      if (!TEMPORAL_OPERATORS.has(operator)) {
+        out[operator] = value
+        continue
+      }
+      out[operator] = Array.isArray(value)
+        ? value.map((v) => coerceTemporalValue(v, kind))
+        : coerceTemporalValue(value, kind)
+    }
+    return out
+  }
+
+  // Bare value: { col: dateLike }
+  return coerceTemporalValue(queryProperty, kind)
+}
+
 export function getSortDirection(order: SortProperty): SortDirection {
   if (typeof order === 'object' && order !== null && 'direction' in order) {
     return order.direction

--- a/test/date-coercion.test.ts
+++ b/test/date-coercion.test.ts
@@ -1,0 +1,213 @@
+import type { Generated } from 'kysely'
+import { Kysely, sql } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import dialect, { getDialect } from './dialect.js'
+import type { DialectType } from './dialect.js'
+import { addPrimaryKey } from './test-utils.js'
+import { KyselyService } from '../src/index.js'
+
+/*
+ * Verifies the opt-in, type-aware date coercion: when `getPropertyType` declares
+ * a column as temporal, the adapter normalizes a Date / ISO string / epoch-ms
+ * number / "YYYY-MM-DD" string query value into the canonical string the driver
+ * compares correctly. This is the fix for the gaps catalogued (uncoerced) in
+ * date-queries.test.ts. With coercion on, every input format yields the SAME
+ * correct rows on every dialect — see the uniform EXPECT table below.
+ */
+
+const dialectName = getDialect()
+
+interface DB {
+  dates: {
+    id: Generated<number>
+    tstz: any
+    ts: any
+    d: any
+  }
+}
+
+type Dates = { id: number; tstz: any; ts: any; d: any }
+
+const COLUMN_DDL: Record<DialectType, Record<'tstz' | 'ts' | 'd', any>> = {
+  postgres: { tstz: sql`timestamptz`, ts: sql`timestamp`, d: sql`date` },
+  mysql: { tstz: sql`timestamp`, ts: sql`datetime`, d: sql`date` },
+  sqlite: { tstz: sql`text`, ts: sql`text`, d: sql`text` },
+}
+
+const INSTANTS = [
+  '2025-06-01T00:00:00.000Z', // r0  well before
+  '2026-01-14T23:59:59.000Z', // r1  day before T
+  '2026-01-15T10:30:00.000Z', // r2  == T (boundary)
+  '2026-01-15T18:00:00.000Z', // r3  later, SAME calendar day as T
+  '2027-03-20T12:00:00.000Z', // r4  well after
+] as const
+const T = INSTANTS[2]
+
+const asDate = (iso: string) => new Date(iso)
+const asIso = (iso: string) => iso
+const asMs = (iso: string) => new Date(iso).getTime()
+const asDateOnly = (iso: string) => iso.slice(0, 10)
+
+const FORMATS = {
+  Date: asDate,
+  ISO: asIso,
+  ms: asMs,
+  'YYYY-MM-DD': asDateOnly,
+} as const
+type Format = keyof typeof FORMATS
+
+const COLUMNS = ['tstz', 'ts', 'd'] as const
+type Column = (typeof COLUMNS)[number]
+
+const OPERATORS = ['$gt', '$gte', '$lt', '$lte', '$eq'] as const
+type Counts = [number, number, number, number, number]
+
+const INSTANT: Counts = [2, 3, 2, 3, 1] // instant columns: compare absolute instant to T
+const DAY: Counts = [1, 3, 2, 4, 2] // date column: compare T's calendar day (r2 & r3 tie)
+const MIDNIGHT: Counts = [3, 3, 2, 2, 0] // date-only on an instant column → UTC midnight of T's day
+
+// With coercion enabled the result is identical on every dialect, with no throws
+// and no timezone dependence (date-only normalizes to an explicit UTC instant).
+const EXPECT: Record<Column, Record<Format, Counts>> = {
+  tstz: { Date: INSTANT, ISO: INSTANT, ms: INSTANT, 'YYYY-MM-DD': MIDNIGHT },
+  ts: { Date: INSTANT, ISO: INSTANT, ms: INSTANT, 'YYYY-MM-DD': MIDNIGHT },
+  d: { Date: DAY, ISO: DAY, ms: DAY, 'YYYY-MM-DD': DAY },
+}
+
+// MySQL wants 'YYYY-MM-DD HH:MM:SS'; postgres + sqlite accept ISO 8601 as-is.
+const storedTimestamp = (iso: string) =>
+  dialectName === 'mysql' ? iso.slice(0, 19).replace('T', ' ') : iso
+
+// Opt-in: declares each column's temporal type so the adapter coerces its values.
+const getPropertyType = (prop: string) =>
+  prop === 'tstz'
+    ? 'timestamptz'
+    : prop === 'ts'
+      ? 'timestamp'
+      : prop === 'd'
+        ? 'date'
+        : undefined
+
+const db = new Kysely<DB>({ dialect: dialect() })
+
+const clean = async () => {
+  await db.schema.dropTable('dates').ifExists().execute()
+  await addPrimaryKey(db.schema.createTable('dates'), 'id')
+    .addColumn('tstz', COLUMN_DDL[dialectName].tstz)
+    .addColumn('ts', COLUMN_DDL[dialectName].ts)
+    .addColumn('d', COLUMN_DDL[dialectName].d)
+    .execute()
+}
+
+const app = feathers<{
+  dates: KyselyService<Dates>
+  datesRaw: KyselyService<Dates>
+}>()
+  .use(
+    'dates',
+    new KyselyService<Dates>({
+      Model: db,
+      id: 'id',
+      name: 'dates',
+      multi: true,
+      getPropertyType,
+    }),
+  )
+  // Same table, NO declared types — used to prove coercion is opt-in.
+  .use(
+    'datesRaw',
+    new KyselyService<Dates>({
+      Model: db,
+      id: 'id',
+      name: 'dates',
+      multi: true,
+    }),
+  )
+
+const seed = () =>
+  app.service('dates').create(
+    INSTANTS.map((iso) => ({
+      tstz: storedTimestamp(iso),
+      ts: storedTimestamp(iso),
+      d: asDateOnly(iso),
+    })),
+  )
+
+const find = (
+  service: 'dates' | 'datesRaw',
+  column: Column,
+  operator: string,
+  value: unknown,
+) =>
+  app.service(service).find({
+    query: { [column]: { [operator]: value } },
+    paginate: false,
+  }) as Promise<Dates[]>
+
+describe(`date coercion (${dialectName})`, () => {
+  beforeEach(async () => {
+    await clean()
+    await seed()
+  })
+  afterAll(() => db.destroy())
+
+  for (const col of COLUMNS) {
+    describe(`${col} column`, () => {
+      for (const format of Object.keys(FORMATS) as Format[]) {
+        it(`${format} input → correct rows`, async () => {
+          const expected = EXPECT[col][format]
+          for (let i = 0; i < OPERATORS.length; i++) {
+            const rows = await find(
+              'dates',
+              col,
+              OPERATORS[i],
+              FORMATS[format](T),
+            )
+            expect(rows, `${col} ${format} ${OPERATORS[i]}`).toHaveLength(
+              expected[i],
+            )
+          }
+        })
+      }
+    })
+  }
+
+  describe('coercion details', () => {
+    it('bare equality with a Date instance matches', async () => {
+      const rows = (await app
+        .service('dates')
+        .find({ query: { tstz: asDate(T) }, paginate: false })) as Dates[]
+      expect(rows).toHaveLength(1)
+    })
+
+    it('$in accepts a mix of input formats', async () => {
+      const rows = await find('dates', 'tstz', '$in', [
+        asDate(INSTANTS[0]),
+        asMs(INSTANTS[2]),
+        asIso(INSTANTS[4]),
+      ])
+      expect(rows).toHaveLength(3)
+    })
+
+    it('$ne null still works (null is not coerced)', async () => {
+      const rows = await find('dates', 'tstz', '$ne', null)
+      expect(rows).toHaveLength(INSTANTS.length)
+    })
+
+    it('is opt-in: an undeclared column does not coerce epoch-ms', async () => {
+      // Declared column: coerced and correct.
+      expect(await find('dates', 'tstz', '$eq', asMs(T))).toHaveLength(1)
+
+      // Same column via a service without declared types: stays broken — the
+      // raw value either throws (Postgres) or matches the wrong rows.
+      let raw: number | 'throws'
+      try {
+        raw = (await find('datesRaw', 'tstz', '$eq', asMs(T))).length
+      } catch {
+        raw = 'throws'
+      }
+      expect(raw).not.toBe(1)
+    })
+  })
+})

--- a/test/date-queries.test.ts
+++ b/test/date-queries.test.ts
@@ -1,0 +1,244 @@
+// Pin the Node process timezone to UTC BEFORE the pg/mysql pools serialize any
+// Date. node-postgres and mysql2 turn a JS `Date` bind param into a wall-clock
+// string in the process timezone; without this pin the `timestamp`-without-tz ×
+// Date-instance cells would shift by the local offset and the assertions below
+// would be machine-dependent. (That shift is itself the footgun documented below.)
+process.env.TZ = 'UTC'
+
+import type { Generated } from 'kysely'
+import { Kysely, sql } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import dialect, { getDialect } from './dialect.js'
+import type { DialectType } from './dialect.js'
+import { addPrimaryKey } from './test-utils.js'
+import { KyselyService } from '../src/index.js'
+
+/*
+ * Characterizes how a date/timestamp query value behaves when supplied as a
+ * Date instance, an ISO 8601 string, an epoch-millisecond number, or a
+ * "YYYY-MM-DD" string — across $gt/$gte/$lt/$lte/$eq, on every dialect and on
+ * three temporal column types.
+ *
+ * The adapter does NO date coercion: the value flows straight to the driver as
+ * a bind parameter (src/adapter.ts buildPropertyExpression/transformOperatorValue),
+ * so behavior is purely (dialect) × (column type) × (JS value type). This file
+ * pins the current reality; the ✗/~ cells are the gap list for an optional,
+ * type-aware coercion feature (would hook src/declarations.ts `getPropertyType`).
+ *
+ * Findings (✓ correct · ~ surprising-but-defensible · ✗ gap), observed values:
+ *   epoch-ms number  ✗ EVERYWHERE — Postgres throws ("out of range"); SQLite &
+ *                      MySQL silently compare number-vs-text/date → wrong rows.
+ *                      The single most broken format.
+ *   Date instance    ✗ SQLite throws (better-sqlite3 cannot bind a Date).
+ *                    ✓ Postgres/MySQL on a real timestamp column.
+ *                    ✗ Postgres `timestamp`-without-tz shifts by the process TZ
+ *                      (here pinned UTC, so it passes — the footgun is silent).
+ *   ISO string       ✓ The portable winner for timestamp columns on all three.
+ *   "YYYY-MM-DD"     ✓ The right format for a DATE column on all three.
+ *                    ~ On a timestamp column it means midnight; on a tz-aware
+ *                      column that midnight is the server session tz (so the
+ *                      boundary is environment-dependent — we assert only the
+ *                      tz-invariant facts there).
+ *   DATE column      ✓ only with a "YYYY-MM-DD" value. A time-bearing value
+ *                      (Date/ISO) is correct on Postgres (time discarded) but
+ *                      ✗ wrong on SQLite/MySQL (the time-of-day shifts the day
+ *                      boundary). SQLite ISO is also wrong because the stored
+ *                      date-only text and the full-ISO probe don't line up.
+ */
+
+const dialectName = getDialect()
+
+interface DB {
+  dates: {
+    id: Generated<number>
+    tstz: any
+    ts: any
+    d: any
+  }
+}
+
+type Dates = { id: number; tstz: any; ts: any; d: any }
+
+// The three temporal column types, mapped to each dialect's real type. SQLite
+// has no native temporal type, so its columns are TEXT holding ISO strings.
+const COLUMN_DDL: Record<DialectType, Record<'tstz' | 'ts' | 'd', any>> = {
+  postgres: { tstz: sql`timestamptz`, ts: sql`timestamp`, d: sql`date` },
+  mysql: { tstz: sql`timestamp`, ts: sql`datetime`, d: sql`date` },
+  sqlite: { tstz: sql`text`, ts: sql`text`, d: sql`text` },
+}
+
+// Fixed instants so every boundary at T is decisive. r2 and r3 deliberately
+// share a calendar day, which is what makes the DATE-column $eq return 2.
+const INSTANTS = [
+  '2025-06-01T00:00:00.000Z', // r0  well before
+  '2026-01-14T23:59:59.000Z', // r1  day before T
+  '2026-01-15T10:30:00.000Z', // r2  == T (boundary)
+  '2026-01-15T18:00:00.000Z', // r3  later, SAME calendar day as T
+  '2027-03-20T12:00:00.000Z', // r4  well after
+] as const
+const T = INSTANTS[2]
+
+const asDate = (iso: string) => new Date(iso)
+const asIso = (iso: string) => iso
+const asMs = (iso: string) => new Date(iso).getTime()
+const asDateOnly = (iso: string) => iso.slice(0, 10) // 'YYYY-MM-DD'
+
+const FORMATS = {
+  Date: asDate,
+  ISO: asIso,
+  ms: asMs,
+  'YYYY-MM-DD': asDateOnly,
+} as const
+type Format = keyof typeof FORMATS
+
+const COLUMNS = ['tstz', 'ts', 'd'] as const
+type Column = (typeof COLUMNS)[number]
+
+const OPERATORS = ['$gt', '$gte', '$lt', '$lte', '$eq'] as const
+type Counts = [number, number, number, number, number] // indexed like OPERATORS
+
+// Named expected shapes (see the matrix in the header comment).
+const INSTANT: Counts = [2, 3, 2, 3, 1] // tstz/ts: compares absolute instants to T
+const DAY: Counts = [1, 3, 2, 4, 2] // DATE col: compares T's calendar day (r2 & r3 tie)
+const MIDNIGHT: Counts = [3, 3, 2, 2, 0] // date-only on a timestamp col → midnight of T's day
+const NUM_VS_TEXT: Counts = [5, 5, 0, 0, 0] // sqlite/mysql: a number sorts before any text/date
+const TIME_SHIFTS_DAY: Counts = [1, 1, 4, 4, 0] // time-bearing probe vs DATE col: time moves the boundary
+const NUM_VS_DATE: Counts = [0, 0, 5, 5, 0] // mysql: a number coerced against a DATE column
+
+const THROWS = 'throws' as const
+const TZ = 'tzInstant' as const // date-only vs a tz-aware column: eq=0, boundary is server-tz-dependent
+type Cell = Counts | typeof THROWS | typeof TZ
+
+const EXPECT: Record<DialectType, Record<Column, Record<Format, Cell>>> = {
+  postgres: {
+    tstz: { Date: INSTANT, ISO: INSTANT, ms: THROWS, 'YYYY-MM-DD': TZ },
+    ts: { Date: INSTANT, ISO: INSTANT, ms: THROWS, 'YYYY-MM-DD': MIDNIGHT },
+    d: { Date: DAY, ISO: DAY, ms: THROWS, 'YYYY-MM-DD': DAY },
+  },
+  sqlite: {
+    tstz: {
+      Date: THROWS,
+      ISO: INSTANT,
+      ms: NUM_VS_TEXT,
+      'YYYY-MM-DD': MIDNIGHT,
+    },
+    ts: { Date: THROWS, ISO: INSTANT, ms: NUM_VS_TEXT, 'YYYY-MM-DD': MIDNIGHT },
+    d: {
+      Date: THROWS,
+      ISO: TIME_SHIFTS_DAY,
+      ms: NUM_VS_TEXT,
+      'YYYY-MM-DD': DAY,
+    },
+  },
+  mysql: {
+    tstz: { Date: INSTANT, ISO: INSTANT, ms: NUM_VS_TEXT, 'YYYY-MM-DD': TZ },
+    ts: {
+      Date: INSTANT,
+      ISO: INSTANT,
+      ms: NUM_VS_TEXT,
+      'YYYY-MM-DD': MIDNIGHT,
+    },
+    d: {
+      Date: TIME_SHIFTS_DAY,
+      ISO: TIME_SHIFTS_DAY,
+      ms: NUM_VS_DATE,
+      'YYYY-MM-DD': DAY,
+    },
+  },
+}
+
+const eqCounts = (a: Counts, b: Counts) => a.every((v, i) => v === b[i])
+
+// Human label for the test name, so `pnpm test` output reads like the matrix.
+function classify(col: Column, format: Format, cell: Cell): string {
+  if (cell === THROWS) return '✗ rejected'
+  if (cell === TZ) return '~ tz-dependent (date→instant)'
+  const semantic = col === 'd' ? DAY : INSTANT
+  if (eqCounts(cell, semantic)) return '✓ correct'
+  if (format === 'YYYY-MM-DD' && eqCounts(cell, MIDNIGHT))
+    return '~ date→midnight'
+  return '✗ wrong rows'
+}
+
+// MySQL wants 'YYYY-MM-DD HH:MM:SS'; postgres + sqlite accept ISO 8601 as-is.
+const storedTimestamp = (iso: string) =>
+  dialectName === 'mysql' ? iso.slice(0, 19).replace('T', ' ') : iso
+
+const db = new Kysely<DB>({ dialect: dialect() })
+
+const clean = async () => {
+  await db.schema.dropTable('dates').ifExists().execute()
+  await addPrimaryKey(db.schema.createTable('dates'), 'id')
+    .addColumn('tstz', COLUMN_DDL[dialectName].tstz)
+    .addColumn('ts', COLUMN_DDL[dialectName].ts)
+    .addColumn('d', COLUMN_DDL[dialectName].d)
+    .execute()
+}
+
+const app = feathers<{ dates: KyselyService<Dates> }>().use(
+  'dates',
+  new KyselyService<Dates>({ Model: db, id: 'id', name: 'dates', multi: true }),
+)
+
+const seed = () =>
+  app.service('dates').create(
+    INSTANTS.map((iso) => ({
+      tstz: storedTimestamp(iso),
+      ts: storedTimestamp(iso),
+      d: asDateOnly(iso),
+    })),
+  )
+
+const find = (column: Column, operator: string, value: unknown) =>
+  app.service('dates').find({
+    query: { [column]: { [operator]: value } },
+    paginate: false,
+  }) as Promise<Dates[]>
+
+describe(`date queries (${dialectName})`, () => {
+  beforeEach(async () => {
+    await clean()
+    await seed()
+  })
+  afterAll(() => db.destroy())
+
+  for (const col of COLUMNS) {
+    describe(`${col} column`, () => {
+      for (const format of Object.keys(FORMATS) as Format[]) {
+        const cell = EXPECT[dialectName][col][format]
+        const probe = () => FORMATS[format](T)
+
+        it(`${format} input → ${classify(col, format, cell)}`, async () => {
+          if (cell === THROWS) {
+            for (const op of OPERATORS) {
+              await expect(find(col, op, probe())).rejects.toThrow()
+            }
+            return
+          }
+
+          if (cell === TZ) {
+            // A "YYYY-MM-DD" value against a tz-aware column is parsed as an
+            // instant (midnight in the DB session timezone), NOT a calendar day.
+            // The exact gt/lt split depends on the server tz, so assert only the
+            // tz-invariant facts.
+            const n: Record<string, number> = {}
+            for (const op of OPERATORS)
+              n[op] = (await find(col, op, probe())).length
+            expect(n['$eq']).toBe(0) // never equals a stored time-of-day
+            expect(n['$gt']).toBe(n['$gte']) // no row sits exactly on the boundary
+            expect(n['$lt']).toBe(n['$lte'])
+            expect(n['$gt'] + n['$lt']).toBe(INSTANTS.length) // boundary splits the set
+            return
+          }
+
+          for (let i = 0; i < OPERATORS.length; i++) {
+            const op = OPERATORS[i]
+            const rows = await find(col, op, probe())
+            expect(rows, `${col} ${format} ${op}`).toHaveLength(cell[i])
+          }
+        })
+      }
+    })
+  }
+})

--- a/test/x-db-type.test.ts
+++ b/test/x-db-type.test.ts
@@ -1,0 +1,256 @@
+import type { Generated } from 'kysely'
+import { Kysely, sql } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import dialect, { getDialect } from './dialect.js'
+import type { DialectType } from './dialect.js'
+import { transformData } from 'feathers-utils'
+import { addPrimaryKey } from './test-utils.js'
+import { KyselyService } from '../src/index.js'
+
+/*
+ * Verifies the declarative `x-db-type` schema annotation as an alternative to a
+ * `getPropertyType` function. The same opt-in, type-aware date coercion (see
+ * date-coercion.test.ts) must kick in when a column declares its database type
+ * via an `x-db-type` key in the `properties` map. Also pins the precedence
+ * rule: an explicit `getPropertyType` wins over the annotation.
+ */
+
+const dialectName = getDialect()
+
+interface DB {
+  xdates: {
+    id: Generated<number>
+    tstz: any
+    plain: any
+  }
+  xjson: {
+    id: Generated<number>
+    data: any
+  }
+}
+
+type Row = { id: number; tstz: any; plain: any }
+
+const COLUMN_DDL: Record<DialectType, any> = {
+  postgres: sql`timestamptz`,
+  mysql: sql`timestamp`,
+  sqlite: sql`text`,
+}
+
+const INSTANTS = [
+  '2025-06-01T00:00:00.000Z', // before T
+  '2026-01-15T10:30:00.000Z', // == T
+  '2027-03-20T12:00:00.000Z', // after T
+] as const
+const T = INSTANTS[1]
+
+const asMs = (iso: string) => new Date(iso).getTime()
+
+// MySQL wants 'YYYY-MM-DD HH:MM:SS'; postgres + sqlite accept ISO 8601 as-is.
+const storedTimestamp = (iso: string) =>
+  dialectName === 'mysql' ? iso.slice(0, 19).replace('T', ' ') : iso
+
+const db = new Kysely<DB>({ dialect: dialect() })
+
+const clean = async () => {
+  await db.schema.dropTable('xdates').ifExists().execute()
+  await addPrimaryKey(db.schema.createTable('xdates'), 'id')
+    .addColumn('tstz', COLUMN_DDL[dialectName])
+    .addColumn('plain', COLUMN_DDL[dialectName])
+    .execute()
+}
+
+const app = feathers<{
+  annotated: KyselyService<Row>
+  fnOverride: KyselyService<Row>
+  raw: KyselyService<Row>
+}>()
+  // Coercion declared purely via the `x-db-type` annotation, no function.
+  .use(
+    'annotated',
+    new KyselyService<Row>({
+      Model: db,
+      id: 'id',
+      name: 'xdates',
+      multi: true,
+      properties: {
+        id: true,
+        tstz: {
+          type: 'string',
+          format: 'date-time',
+          'x-db-type': 'timestamptz',
+        },
+        plain: true,
+      },
+    }),
+  )
+  // Explicit function must win over the annotation: it suppresses coercion on
+  // `tstz` (returns a non-temporal type) while the annotation says timestamptz.
+  .use(
+    'fnOverride',
+    new KyselyService<Row>({
+      Model: db,
+      id: 'id',
+      name: 'xdates',
+      multi: true,
+      getPropertyType: (prop) => (prop === 'tstz' ? 'json' : undefined),
+      properties: {
+        tstz: { 'x-db-type': 'timestamptz' },
+        plain: true,
+      },
+    }),
+  )
+  // No declared types at all — used to prove coercion is opt-in.
+  .use(
+    'raw',
+    new KyselyService<Row>({
+      Model: db,
+      id: 'id',
+      name: 'xdates',
+      multi: true,
+    }),
+  )
+
+const seed = () =>
+  app.service('annotated').create(
+    INSTANTS.map((iso) => ({
+      tstz: storedTimestamp(iso),
+      plain: storedTimestamp(iso),
+    })),
+  )
+
+const eqCount = async (
+  service: 'annotated' | 'fnOverride' | 'raw',
+  column: 'tstz' | 'plain',
+  value: unknown,
+) =>
+  (
+    (await app.service(service).find({
+      query: { [column]: { $eq: value } },
+      paginate: false,
+    })) as Row[]
+  ).length
+
+describe(`x-db-type annotation (${dialectName})`, () => {
+  beforeEach(async () => {
+    await clean()
+    await seed()
+  })
+
+  it('coerces epoch-ms via the x-db-type annotation alone', async () => {
+    expect(await eqCount('annotated', 'tstz', asMs(T))).toBe(1)
+  })
+
+  it('is opt-in: an unannotated column is not coerced', async () => {
+    // Same physical column, but `plain` carries no annotation, so the raw
+    // epoch-ms value is not normalized: it either throws (Postgres) or matches
+    // the wrong rows. Either way it does not behave like a coerced column.
+    let result: number | 'throws'
+    try {
+      result = await eqCount('annotated', 'plain', asMs(T))
+    } catch {
+      result = 'throws'
+    }
+    expect(result).not.toBe(1)
+  })
+
+  it('is opt-in: a service with no declared types does not coerce', async () => {
+    let raw: number | 'throws'
+    try {
+      raw = await eqCount('raw', 'tstz', asMs(T))
+    } catch {
+      raw = 'throws'
+    }
+    expect(raw).not.toBe(1)
+  })
+
+  it('explicit getPropertyType takes precedence over x-db-type', async () => {
+    // The function maps `tstz` to a non-temporal type, so no coercion happens
+    // even though the annotation says timestamptz — proving the function wins.
+    let result: number | 'throws'
+    try {
+      result = await eqCount('fnOverride', 'tstz', asMs(T))
+    } catch {
+      result = 'throws'
+    }
+    expect(result).not.toBe(1)
+  })
+})
+
+/*
+ * jsonb dot-notation traversal driven purely by an `x-db-type: 'jsonb'`
+ * annotation (no getPropertyType function). jsonb is Postgres-only. Shares the
+ * single `db`/pool above; teardown happens in the top-level afterAll.
+ */
+type JsonRow = { id: number; data: any }
+
+const jsonApp = feathers<{ docs: KyselyService<JsonRow> }>().use(
+  'docs',
+  new KyselyService<JsonRow>({
+    Model: db,
+    id: 'id',
+    name: 'xjson',
+    multi: true,
+    properties: {
+      id: true,
+      data: { type: 'object', 'x-db-type': 'jsonb' },
+    },
+  }),
+)
+
+jsonApp.service('docs').hooks({
+  before: {
+    create: [
+      transformData((data) => {
+        if (data.data) data.data = JSON.stringify(data.data)
+      }),
+    ],
+  },
+})
+
+describe.skipIf(dialectName !== 'postgres')(
+  'x-db-type jsonb dot-notation (postgres)',
+  () => {
+    beforeEach(async () => {
+      await db.schema.dropTable('xjson').ifExists().execute()
+      await addPrimaryKey(db.schema.createTable('xjson'), 'id')
+        .addColumn('data', 'jsonb')
+        .execute()
+    })
+
+    it('queries a nested jsonb path via x-db-type annotation', async () => {
+      await jsonApp
+        .service('docs')
+        .create([
+          { data: { a: { b: { c: 1 } } } },
+          { data: { a: { b: { c: 2 } } } },
+          { data: { a: { b: { c: 3 } } } },
+        ])
+
+      const queried = (await jsonApp.service('docs').find({
+        query: { 'data.a.b.c': { $gte: 2 } },
+        paginate: false,
+      })) as JsonRow[]
+
+      expect(queried).toHaveLength(2)
+      expect(queried.map((r) => r.data.a.b.c).sort()).toEqual([2, 3])
+    })
+
+    it('queries a top-level jsonb key via x-db-type annotation', async () => {
+      await jsonApp
+        .service('docs')
+        .create([{ data: { name: 'John' } }, { data: { name: 'Test' } }])
+
+      const queried = (await jsonApp.service('docs').find({
+        query: { 'data.name': 'John' },
+        paginate: false,
+      })) as JsonRow[]
+
+      expect(queried).toHaveLength(1)
+      expect(queried[0].data).toEqual({ name: 'John' })
+    })
+  },
+)
+
+afterAll(() => db.destroy())


### PR DESCRIPTION
This pull request introduces opt-in, type-aware date coercion for temporal columns in the Kysely adapter. By declaring a column's database type—either via a JSON schema annotation (`x-db-type`) or a `getPropertyType` function—the adapter will now normalize various JavaScript date representations (Date, ISO string, epoch-ms, or "YYYY-MM-DD" string) into a canonical format that works consistently across all supported SQL dialects. The documentation is updated to explain these features, and comprehensive tests verify the new behavior.

**Core feature: Type-aware date coercion**
- Query values for columns declared as temporal types (`date`, `timestamp`, etc.) are now automatically normalized, ensuring consistent and correct query results regardless of input format or database dialect. This is opt-in per column. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R96-R194) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL918-R947) [[3]](diffhunk://#diff-1f470969cbf07fbc4146869d0840606a40a38a3875b7f4f9af9668e7447bac15R1-R213)

**Configuration and schema enhancements**
- Added support for declaring column types via a new `x-db-type` property in `properties`, or via a `getPropertyType` function, with clear precedence and documentation. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR824-R855) [[2]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986L27-R63) [[3]](diffhunk://#diff-e0860561ccbb82394d77a07844ab75e9da88ace9d434177b42e4d6babeaf874eL43-R87)

**Documentation improvements**
- Expanded documentation in `docs/api/service.md` and `docs/api/operators.md` to explain how to declare column types and how date coercion and JSON column querying work. [[1]](diffhunk://#diff-e0860561ccbb82394d77a07844ab75e9da88ace9d434177b42e4d6babeaf874eL43-R87) [[2]](diffhunk://#diff-1ab7f1f3bb8f7d4954c4969f321b3680a012e94f7704d723b74ebd1545da8bffR53-R125)

**Other changes**
- Removed `CHANGELOG.md` from the repo and from published files. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-L4) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26)

---

**Encoded references:**  
[[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R96-R194) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL918-R947) [[3]](diffhunk://#diff-1f470969cbf07fbc4146869d0840606a40a38a3875b7f4f9af9668e7447bac15R1-R213) [[4]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR824-R855) [[5]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986L27-R63) [[6]](diffhunk://#diff-e0860561ccbb82394d77a07844ab75e9da88ace9d434177b42e4d6babeaf874eL43-R87) [[7]](diffhunk://#diff-1ab7f1f3bb8f7d4954c4969f321b3680a012e94f7704d723b74ebd1545da8bffR53-R125) [[8]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-L4) [[9]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26)