### PR TITLE
fix: skip cjs named export from feathersjs/feathers

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,5 @@
 import { createDebug } from '@feathersjs/commons'
 import type { HookContext, NextFunction } from '@feathersjs/feathers'
-import { getServiceOptions } from '@feathersjs/feathers'
 import type { ControlledTransaction, Kysely } from 'kysely'
 import type {
   KyselyAdapterParams,
@@ -249,7 +248,11 @@ export const withTransaction =
       const self = context.self
       const event = context.event
       if (typeof event === 'string' && transaction.deferredEvents) {
-        const events = getServiceOptions(self).events ?? []
+        // Mirrors @feathersjs/feathers' eventHook: skip the default emit when the
+        // service declares this event itself. We read `self.events` directly instead
+        // of `getServiceOptions()` to avoid a value import of the CJS-only
+        // @feathersjs/feathers, which breaks our ESM consumers.
+        const events: string[] = (self as any).events ?? []
         if (!events.includes(event)) {
           const results = Array.isArray(context.result)
             ? context.result


### PR DESCRIPTION
This pull request makes a targeted change to the `withTransaction` hook in `src/hooks.ts` to improve compatibility with ESM consumers. The main update is to avoid importing a CommonJS-only utility, which could break ESM usage, by directly accessing a property on the service object.

**Compatibility improvement:**

* The `withTransaction` hook now accesses the `events` property directly from the service instance (`self.events`) instead of importing and using `getServiceOptions` from `@feathersjs/feathers`, preventing issues for ESM consumers. [[1]](diffhunk://#diff-a2d969770fbca6d31b2bcb062b5d406aa54f9ddebef57996faacc6f82e746e42L3) [[2]](diffhunk://#diff-a2d969770fbca6d31b2bcb062b5d406aa54f9ddebef57996faacc6f82e746e42L252-R255)