### PR TITLE
feat: create onConflict

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,8 @@
       "Bash(pnpm view *)",
       "Bash(DB=sqlite pnpm vitest run)",
       "Bash(pnpm exec *)",
-      "Bash(echo \"=== tsc exit: $? ===\")"
+      "Bash(echo \"=== tsc exit: $? ===\")",
+      "Bash(pnpm typecheck *)"
     ]
   }
 }

--- a/docs/guides/upsert.md
+++ b/docs/guides/upsert.md
@@ -1,49 +1,89 @@
 # Upsert
 
-The service provides an `upsert` method using `ON CONFLICT` (PostgreSQL/SQLite) or `ON DUPLICATE KEY UPDATE` (MySQL).
+`create` can perform an upsert using `ON CONFLICT` (PostgreSQL/SQLite) or
+`ON DUPLICATE KEY UPDATE` (MySQL). Pass the conflict options under
+`params.kysely`:
 
 ```ts
-const result = await app.service("users").upsert(
+const result = await app.service("users").create(
   { name: "Alice", age: 31 },
   {
-    onConflictFields: ["name"],
-    onConflictAction: "merge", // 'merge' (default) or 'ignore'
+    kysely: {
+      onConflictFields: ["name"],
+      onConflictAction: "merge", // 'merge' or 'ignore' (default)
+    },
   },
 );
 ```
 
+Because this is a regular `create`, it runs through the standard Feathers
+pipeline: it emits the `created` event, runs your hooks, and participates in
+transaction event deferral.
+
+::: warning Event semantics
+`create` always emits `created`, even when a conflict occurs. With
+`onConflictAction: 'ignore'` and an existing row, the call returns that row
+without inserting — but a `created` event is still emitted. This is inherent to
+the standard pipeline; if you need different event semantics, handle it in a hook.
+:::
+
 ## Options
 
-| Option                   | Type       | Default   | Description                              |
-| ------------------------ | ---------- | --------- | ---------------------------------------- |
-| `onConflictFields`       | `string[]` | _required_ | Fields to use in the `ON CONFLICT` clause |
-| `onConflictAction`       | `string`   | `'merge'` | `'merge'` or `'ignore'`                  |
-| `onConflictMergeFields`  | `string[]` | —         | Specific fields to update on conflict     |
-| `onConflictExcludeFields`| `string[]` | —         | Fields to exclude from update             |
+All options live under `params.kysely`:
+
+| Option                    | Type       | Default    | Description                               |
+| ------------------------- | ---------- | ---------- | ----------------------------------------- |
+| `onConflictFields`        | `string[]` | _required_ | Fields to use in the `ON CONFLICT` clause |
+| `onConflictAction`        | `string`   | `'ignore'` | `'merge'` or `'ignore'`                    |
+| `onConflictMergeFields`   | `string[]` | —          | Specific fields to update on conflict     |
+| `onConflictExcludeFields` | `string[]` | —          | Fields to exclude from update             |
+
+Conflict handling only kicks in when `onConflictFields` is set. Without it,
+`create` is a plain insert.
 
 ### Merge vs Ignore
 
 - **`merge`** — updates the existing row with the new values (`ON CONFLICT DO UPDATE`)
-- **`ignore`** — keeps the existing row unchanged (`ON CONFLICT DO NOTHING`)
+- **`ignore`** — keeps the existing row unchanged (`ON CONFLICT DO NOTHING`), returns the existing row
 
 ### Controlling Merged Fields
 
 ```ts
 // Only update the age field on conflict
-await app.service("users").upsert(
+await app.service("users").create(
   { name: "Alice", age: 31 },
   {
-    onConflictFields: ["name"],
-    onConflictMergeFields: ["age"],
+    kysely: {
+      onConflictFields: ["name"],
+      onConflictAction: "merge",
+      onConflictMergeFields: ["age"],
+    },
   },
 );
 
 // Update everything except the name field
-await app.service("users").upsert(
+await app.service("users").create(
   { name: "Alice", age: 31 },
   {
-    onConflictFields: ["name"],
-    onConflictExcludeFields: ["name"],
+    kysely: {
+      onConflictFields: ["name"],
+      onConflictAction: "merge",
+      onConflictExcludeFields: ["name"],
+    },
   },
+);
+```
+
+## Deprecated: `upsert` method
+
+The dedicated `upsert` method still works but is **deprecated**. It takes the
+same options as top-level params and forwards them to `create`. Unlike `create`,
+it does **not** emit events or run through the standard pipeline.
+
+```ts
+// Deprecated — prefer create(data, { kysely: { ... } })
+await app.service("users").upsert(
+  { name: "Alice", age: 31 },
+  { onConflictFields: ["name"], onConflictAction: "merge" },
 );
 ```

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -24,6 +24,7 @@ import type {
   DialectType,
   KyselyAdapterOptions,
   KyselyAdapterParams,
+  KyselyParams,
   Relation,
   UpsertOptions,
 } from './declarations.js'
@@ -1646,7 +1647,7 @@ export class KyselyAdapter<
     params: ServiceParams = {} as ServiceParams,
   ): Promise<Result | Result[]> {
     const { filters, options } = this.filterQuery(params)
-    const { name, id: idField } = options
+    const { name, id: idField, dialectType } = options
     const isArray = Array.isArray(_data)
 
     if (isArray && _data.length === 0) {
@@ -1655,56 +1656,18 @@ export class KyselyAdapter<
 
     const $select = applySelectId(filters.$select, idField)
 
-    const q = this.db(params)
-      .insertInto(name)
-      .values(this.convertValues(_data) as any)
-
-    const returning = this.applyReturning(q, $select)
-
-    const response = await this.executeAndReturn(returning, {
-      isArray,
-      options,
-      params,
-      $select,
-      data: _data,
-    })
-
-    return response
-  }
-
-  async _upsert(
-    data: Data,
-    params: ServiceParams & UpsertOptions<Result>,
-  ): Promise<Result>
-  async _upsert(
-    data: Data[],
-    params: ServiceParams & UpsertOptions<Result>,
-  ): Promise<Result[]>
-  async _upsert(
-    data: Data | Data[],
-    _params: ServiceParams & UpsertOptions<Result>,
-  ): Promise<Result | Result[]>
-  async _upsert(
-    _data: Data | Data[],
-    params: ServiceParams & UpsertOptions<Result>,
-  ): Promise<Result | Result[]> {
-    const { filters, options } = this.filterQuery(params)
-    const { name, id: idField, dialectType } = options
-    const isArray = Array.isArray(_data)
-    const $select = applySelectId(filters.$select, idField)
-
     const {
       onConflictFields = [],
       onConflictAction = 'ignore',
       onConflictMergeFields,
       onConflictExcludeFields = [],
-    } = params
+    } = (params as { kysely?: KyselyParams<Result> }).kysely ?? {}
 
     let q = this.db(params)
       .insertInto(name)
       .values(this.convertValues(_data) as any)
 
-    // Apply conflict resolution based on database dialect
+    // Apply conflict resolution based on database dialect (upsert via create)
     if (onConflictFields.length > 0) {
       const upsertOptions = {
         onConflictAction,
@@ -1841,6 +1804,52 @@ export class KyselyAdapter<
     }
 
     return response
+  }
+
+  /**
+   * @deprecated Use `create(data, { kysely: { onConflictFields, ... } })`
+   * instead. `create` runs through the standard Feathers pipeline (emits
+   * `created`, runs hooks, participates in transaction event deferral); this
+   * method does not. The conflict-resolution logic now lives in `_create`; this
+   * method simply forwards its options through `params.kysely`.
+   */
+  async _upsert(
+    data: Data,
+    params: ServiceParams & UpsertOptions<Result>,
+  ): Promise<Result>
+  async _upsert(
+    data: Data[],
+    params: ServiceParams & UpsertOptions<Result>,
+  ): Promise<Result[]>
+  async _upsert(
+    data: Data | Data[],
+    _params: ServiceParams & UpsertOptions<Result>,
+  ): Promise<Result | Result[]>
+  async _upsert(
+    _data: Data | Data[],
+    params: ServiceParams & UpsertOptions<Result>,
+  ): Promise<Result | Result[]> {
+    const {
+      onConflictFields,
+      onConflictAction,
+      onConflictMergeFields,
+      onConflictExcludeFields,
+      ...rest
+    } = params
+
+    return this._create(
+      _data as any,
+      {
+        ...rest,
+        kysely: {
+          onConflictFields,
+          onConflictAction,
+          onConflictMergeFields,
+          onConflictExcludeFields,
+          ...rest?.kysely,
+        },
+      } as unknown as ServiceParams,
+    )
   }
 
   private async getWhereForUpdateOrDelete<

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -84,17 +84,24 @@ export interface KyselyAdapterTransaction {
   deferredEvents?: Array<() => void>
 }
 
-export interface UpsertOptions<T = any> {
+/**
+ * Kysely-specific options passed through `params.kysely`. Currently exposes
+ * `ON CONFLICT` / `ON DUPLICATE KEY UPDATE` handling for `create`, turning a
+ * `create` call into an upsert while keeping the standard Feathers pipeline
+ * (events, hooks, transaction event deferral).
+ */
+export interface KyselyParams<T = any> {
   /**
-   * Fields to use in the ON CONFLICT clause
+   * Fields to use in the `ON CONFLICT` clause. When set, `create` performs an
+   * upsert instead of a plain insert.
    */
-  onConflictFields: (keyof T)[]
+  onConflictFields?: (keyof T)[]
   /**
    * Action to take on conflict: 'ignore' or 'merge'
    * - 'ignore': Do nothing on conflict (ON CONFLICT DO NOTHING)
    * - 'merge': Update the row on conflict (ON CONFLICT DO UPDATE)
    *
-   * @default 'merge'
+   * @default 'ignore'
    */
   onConflictAction?: 'ignore' | 'merge'
   /**
@@ -109,9 +116,26 @@ export interface UpsertOptions<T = any> {
   onConflictExcludeFields?: (keyof T)[]
 }
 
+/**
+ * @deprecated Use `create(data, { kysely: { onConflictFields, ... } })` instead.
+ * `create` runs through the standard Feathers pipeline (emits `created`, runs
+ * hooks, participates in transaction event deferral); the `upsert` method does
+ * not. See {@link KyselyParams}.
+ */
+export interface UpsertOptions<T = any> extends Omit<KyselyParams<T>, 'onConflictFields'> {
+  /**
+   * Fields to use in the ON CONFLICT clause
+   */
+  onConflictFields: (keyof T)[]
+}
+
 export interface KyselyAdapterParams<Q extends AdapterQuery = AdapterQuery>
   extends AdapterParams<Q, Partial<KyselyAdapterOptions>> {
   transaction?: KyselyAdapterTransaction
+  /**
+   * Kysely-specific options. See {@link KyselyParams}.
+   */
+  kysely?: KyselyParams
 }
 
 export type SortDirection =

--- a/src/service.ts
+++ b/src/service.ts
@@ -54,6 +54,12 @@ export class KyselyService<
     return this._create(data, params)
   }
 
+  /**
+   * @deprecated Use `create(data, { kysely: { onConflictFields, ... } })`
+   * instead. Unlike `upsert`, `create` runs through the standard Feathers
+   * pipeline — it emits the `created` event, runs hooks, and participates in
+   * transaction event deferral.
+   */
   async upsert(
     data: Data,
     params: ServiceParams & UpsertOptions<Result>,

--- a/test/create-conflict.test.ts
+++ b/test/create-conflict.test.ts
@@ -1,0 +1,363 @@
+import type { Generated } from 'kysely'
+import { Kysely } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import dialect, { getDialect } from './dialect.js'
+
+import { KyselyService } from '../src/index.js'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { addPrimaryKey } from './test-utils.js'
+
+interface ProductsTable {
+  id: Generated<number>
+  sku: string
+  name: string
+  price: number
+  stock?: number
+  description?: string
+}
+
+interface DB {
+  products: ProductsTable
+}
+
+type Product = {
+  id: number
+  sku: string
+  name: string
+  price: number
+  stock: number | null
+  description: string | null
+}
+
+const dialectType = getDialect()
+
+function setup() {
+  const db = new Kysely<DB>({
+    dialect: dialect(),
+  })
+
+  const clean = async () => {
+    await db.schema.dropTable('products').ifExists().execute()
+
+    // Use varchar for MySQL (text can't have unique index without prefix length)
+    const textType = dialectType === 'mysql' ? 'varchar(255)' : 'text'
+
+    const builder = addPrimaryKey(
+      db.schema
+        .createTable('products')
+        .addColumn('sku', textType, (col) => col.notNull().unique())
+        .addColumn('name', textType, (col) => col.notNull())
+        .addColumn('price', 'real', (col) => col.notNull())
+        .addColumn('stock', 'real')
+        .addColumn('description', textType),
+      'id',
+    )
+
+    await builder.execute()
+  }
+
+  const app = feathers<{
+    products: KyselyService<Product>
+  }>().use(
+    'products',
+    new KyselyService<Product>({
+      Model: db,
+      name: 'products',
+      multi: true,
+      properties: {
+        sku: { type: 'string' },
+        name: { type: 'string' },
+        price: { type: 'number' },
+        stock: { type: 'number' },
+        description: { type: 'string' },
+      },
+    }),
+  )
+
+  return {
+    db,
+    clean,
+    products: app.service('products'),
+    app,
+  }
+}
+
+const { app, db, clean } = setup()
+
+describe('create with params.kysely conflict handling', () => {
+  beforeEach(clean)
+
+  afterAll(() => db.destroy())
+
+  describe('plain create (no kysely options)', () => {
+    it('still inserts a record unchanged', async () => {
+      const result = await app.service('products').create({
+        sku: 'PLAIN-001',
+        name: 'Plain Product',
+        price: 9.99,
+        stock: 3,
+      })
+
+      expect(result).toMatchObject({
+        sku: 'PLAIN-001',
+        name: 'Plain Product',
+        price: 9.99,
+        stock: 3,
+      })
+      expect(result.id).toBeDefined()
+    })
+  })
+
+  describe('single record', () => {
+    it('inserts when there is no conflict', async () => {
+      const result = await app
+        .service('products')
+        .create(
+          { sku: 'C-001', name: 'Test Product', price: 99.99, stock: 10 },
+          { kysely: { onConflictFields: ['sku'] } },
+        )
+
+      expect(result).toMatchObject({
+        sku: 'C-001',
+        name: 'Test Product',
+        price: 99.99,
+        stock: 10,
+      })
+      expect(result.id).toBeDefined()
+    })
+
+    it('ignores the conflict and returns the existing row (default action)', async () => {
+      const initial = await app.service('products').create({
+        sku: 'C-002',
+        name: 'Original Product',
+        price: 50.0,
+        stock: 5,
+      })
+
+      const result = await app
+        .service('products')
+        .create(
+          { sku: 'C-002', name: 'Updated Product', price: 75.0, stock: 15 },
+          { kysely: { onConflictFields: ['sku'] } },
+        )
+
+      expect(result).toMatchObject({
+        id: initial.id,
+        sku: 'C-002',
+        name: 'Original Product',
+        price: 50.0,
+        stock: 5,
+      })
+    })
+
+    it('merges all fields on conflict', async () => {
+      const initial = await app.service('products').create({
+        sku: 'C-003',
+        name: 'Original Product',
+        price: 50.0,
+        stock: 5,
+        description: 'Original description',
+      })
+
+      const result = await app.service('products').create(
+        {
+          sku: 'C-003',
+          name: 'Updated Product',
+          price: 75.0,
+          stock: 15,
+          description: 'New description',
+        },
+        { kysely: { onConflictFields: ['sku'], onConflictAction: 'merge' } },
+      )
+
+      expect(result).toMatchObject({
+        id: initial.id,
+        sku: 'C-003',
+        name: 'Updated Product',
+        price: 75.0,
+        stock: 15,
+        description: 'New description',
+      })
+    })
+
+    it('merges only the specified onConflictMergeFields', async () => {
+      const initial = await app.service('products').create({
+        sku: 'C-004',
+        name: 'Original Product',
+        price: 50.0,
+        stock: 5,
+      })
+
+      const result = await app.service('products').create(
+        { sku: 'C-004', name: 'Updated Product', price: 75.0, stock: 15 },
+        {
+          kysely: {
+            onConflictFields: ['sku'],
+            onConflictAction: 'merge',
+            onConflictMergeFields: ['price'],
+          },
+        },
+      )
+
+      expect(result).toMatchObject({
+        id: initial.id,
+        sku: 'C-004',
+        name: 'Original Product', // unchanged
+        price: 75.0, // merged
+        stock: 5, // unchanged
+      })
+    })
+
+    it('excludes onConflictExcludeFields from the merge', async () => {
+      const initial = await app.service('products').create({
+        sku: 'C-005',
+        name: 'Original Product',
+        price: 50.0,
+        stock: 5,
+      })
+
+      const result = await app.service('products').create(
+        { sku: 'C-005', name: 'Updated Product', price: 75.0, stock: 15 },
+        {
+          kysely: {
+            onConflictFields: ['sku'],
+            onConflictAction: 'merge',
+            onConflictExcludeFields: ['name'],
+          },
+        },
+      )
+
+      expect(result).toMatchObject({
+        id: initial.id,
+        sku: 'C-005',
+        name: 'Original Product', // excluded from merge
+        price: 75.0, // merged
+        stock: 15, // merged
+      })
+    })
+  })
+
+  describe('multiple records', () => {
+    it('inserts new and ignores existing on a mixed batch', async () => {
+      await app.service('products').create({
+        sku: 'M-001',
+        name: 'Existing',
+        price: 10,
+        stock: 1,
+      })
+
+      const result = (await app.service('products').create(
+        [
+          { sku: 'M-001', name: 'Existing Updated', price: 99, stock: 9 },
+          { sku: 'M-002', name: 'Fresh', price: 20, stock: 2 },
+        ],
+        { kysely: { onConflictFields: ['sku'], onConflictAction: 'ignore' } },
+      )) as Product[]
+
+      expect(result).toHaveLength(2)
+      const bySku = Object.fromEntries(result.map((r) => [r.sku, r]))
+      // existing returned unchanged
+      expect(bySku['M-001']).toMatchObject({ name: 'Existing', price: 10 })
+      // fresh inserted
+      expect(bySku['M-002']).toMatchObject({ name: 'Fresh', price: 20 })
+    })
+
+    it('merges existing on a batch', async () => {
+      await app.service('products').create({
+        sku: 'M-010',
+        name: 'Existing',
+        price: 10,
+        stock: 1,
+      })
+
+      const result = (await app.service('products').create(
+        [
+          { sku: 'M-010', name: 'Existing Updated', price: 99, stock: 9 },
+          { sku: 'M-011', name: 'Fresh', price: 20, stock: 2 },
+        ],
+        { kysely: { onConflictFields: ['sku'], onConflictAction: 'merge' } },
+      )) as Product[]
+
+      expect(result).toHaveLength(2)
+      const bySku = Object.fromEntries(result.map((r) => [r.sku, r]))
+      expect(bySku['M-010']).toMatchObject({
+        name: 'Existing Updated',
+        price: 99,
+        stock: 9,
+      })
+      expect(bySku['M-011']).toMatchObject({ name: 'Fresh', price: 20 })
+    })
+  })
+
+  describe('feathers events (the reason to prefer create over upsert)', () => {
+    it('emits "created" when inserting via create + conflict options', async () => {
+      const events: Product[] = []
+      const handler = (product: Product) => events.push(product)
+      app.service('products').on('created', handler)
+
+      try {
+        await app
+          .service('products')
+          .create(
+            { sku: 'E-001', name: 'Eventful', price: 5, stock: 1 },
+            { kysely: { onConflictFields: ['sku'] } },
+          )
+      } finally {
+        app.service('products').removeListener('created', handler)
+      }
+
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({ sku: 'E-001', name: 'Eventful' })
+    })
+
+    it('still emits "created" even when the conflict is ignored', async () => {
+      await app.service('products').create({
+        sku: 'E-002',
+        name: 'Original',
+        price: 5,
+        stock: 1,
+      })
+
+      const events: Product[] = []
+      const handler = (product: Product) => events.push(product)
+      app.service('products').on('created', handler)
+
+      try {
+        const result = await app.service('products').create(
+          { sku: 'E-002', name: 'Ignored Update', price: 99, stock: 9 },
+          {
+            kysely: { onConflictFields: ['sku'], onConflictAction: 'ignore' },
+          },
+        )
+        // returns the pre-existing row...
+        expect(result).toMatchObject({ name: 'Original' })
+      } finally {
+        app.service('products').removeListener('created', handler)
+      }
+
+      // ...but the standard pipeline still emits `created` (documented caveat)
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({ sku: 'E-002', name: 'Original' })
+    })
+  })
+
+  describe('empty array edge case', () => {
+    it('create([], { kysely }) resolves to [] without hitting the database', async () => {
+      const result = await app
+        .service('products')
+        .create([], { kysely: { onConflictFields: ['sku'] } })
+
+      expect(result).toEqual([])
+    })
+
+    it('deprecated upsert([]) resolves to [] (delegates to create)', async () => {
+      // The old `_upsert` had no empty-array guard and would emit an invalid
+      // empty multi-INSERT; delegating to `_create` makes this a safe no-op.
+      const result = await app
+        .service('products')
+        .upsert([], { onConflictFields: ['sku'] } as any)
+
+      expect(result).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
This pull request refactors and improves how upsert (insert-or-update) functionality is handled in the Kysely adapter. The main change is that upsert is now performed through the standard `create` method using new `params.kysely` options, which allows upserts to participate fully in the Feathers pipeline (including events, hooks, and transaction event deferral). The dedicated `upsert` method is now deprecated and simply delegates to `create`. The documentation and type definitions have been updated to reflect this new approach, and comprehensive tests have been added for the new behavior.

**Upsert via `create` (new preferred approach):**
- The `create` method can now perform upserts by passing conflict options under `params.kysely` (e.g., `onConflictFields`, `onConflictAction`, etc.), which enables upsert logic while preserving the standard Feathers pipeline and event semantics. (`src/adapter.ts` [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL1658-R1670) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL1649-R1650) [[3]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986L87-R104) [[4]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986R119-R138); `docs/guides/upsert.md` [[5]](diffhunk://#diff-32c286d4d650ca82c6432f5081e5cb82ee838b0918100b0077a2504910c5b92fL3-R87)

**Deprecation and delegation of the old `upsert` method:**
- The dedicated `upsert` method is now marked as deprecated, updated to forward its options to `create`, and no longer emits events or runs hooks itself. (`src/adapter.ts` [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR1809-R1854); `src/service.ts` [[2]](diffhunk://#diff-84b68bce2abfcb25c3328df0286963d7dacc924940adc41923bf4f502a6bc95aR57-R62); `docs/guides/upsert.md` [[3]](diffhunk://#diff-32c286d4d650ca82c6432f5081e5cb82ee838b0918100b0077a2504910c5b92fL3-R87)

**Documentation and type updates:**
- The upsert documentation has been rewritten to explain the new `create`-based approach, event semantics, and deprecation of the old method. Type definitions have been updated to introduce `KyselyParams` for conflict options and clarify usage. (`docs/guides/upsert.md` [[1]](diffhunk://#diff-32c286d4d650ca82c6432f5081e5cb82ee838b0918100b0077a2504910c5b92fL3-R87); `src/declarations.ts` [[2]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986L87-R104) [[3]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986R119-R138) [[4]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR27)

**Testing improvements:**
- A comprehensive new test suite verifies all aspects of the new upsert-via-create behavior, including conflict handling, field merging/exclusion, event emission, batch operations, and edge cases. (`test/create-conflict.test.ts` [test/create-conflict.test.tsR1-R363](diffhunk://#diff-57bc073a6815d55ba2f57c6a6e47f3992a458495bf1bc0f5b99f1d2def90213aR1-R363))

**Development tooling:**
- The pnpm typecheck command is now included in the allowed commands for the development environment. (`.claude/settings.json` [.claude/settings.jsonL14-R15](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L14-R15))