### PR TITLE
feat: update operators

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         items: [
           { text: 'Service & Options', link: '/api/service' },
           { text: 'Query Operators', link: '/api/operators' },
+          { text: 'Update Operators', link: '/api/update-operators' },
           { text: 'Transactions', link: '/api/transactions' },
         ],
       },

--- a/docs/api/update-operators.md
+++ b/docs/api/update-operators.md
@@ -1,0 +1,175 @@
+# Update Operators
+
+MongoDB-style atomic update operators for `patch`, provided by the
+`updateOperators()` hook. Unlike [query operators](/api/operators) (which build
+`WHERE` clauses), these build `SET` clauses — they modify a column based on its
+current value instead of overwriting it, computed in the database in a single
+statement.
+
+| Operator | SQL                            | Description                           |
+| -------- | ------------------------------ | ------------------------------------- |
+| `$inc`   | `col = col + value`            | Increment (or decrement)              |
+| `$mul`   | `col = col * value`            | Multiply                              |
+| `$min`   | `col = least(col, value)`\*    | Keep the smaller of current and value |
+| `$max`   | `col = greatest(col, value)`\* | Keep the larger of current and value  |
+| `$push`  | append to an array column      | Add element(s) to an array            |
+| `$pull`  | remove from an array column    | Remove element(s) from an array       |
+
+\* `$min` / `$max` compile to a portable `CASE` expression
+(`case when col is null or col > value then value else col end`) rather than
+`LEAST`/`GREATEST`, so they work identically on PostgreSQL, MySQL and SQLite. A
+`NULL` column is treated as "no value yet" and initialized to `value`.
+
+## Setup
+
+`updateOperators()` is an opt-in hook. Register it on `patch` — and on `update`
+too, so misuse there fails loudly (see [below](#patch-only)). It works as a
+`before` **or** an `around` hook:
+
+```ts
+import { updateOperators } from "@fratzinger/feathers-kysely";
+
+app.service("users").hooks({
+  before: {
+    patch: [updateOperators()],
+    update: [updateOperators()],
+  },
+});
+```
+
+## Usage
+
+`$inc` increments a column atomically (a negative value decrements):
+
+```ts
+// SET views = views + 1
+await app.service("articles").patch(id, { $inc: { views: 1 } });
+
+// SET stock = stock - 5
+await app.service("products").patch(id, { $inc: { stock: -5 } });
+```
+
+`$mul` multiplies a column:
+
+```ts
+// SET price = price * 2
+await app.service("products").patch(id, { $mul: { price: 2 } });
+```
+
+`$min` / `$max` clamp a column to the smaller / larger of its current value and
+the given value — useful for low-water / high-water marks (lowest price seen,
+highest score). A `NULL` column is initialized to the value:
+
+```ts
+// only lowers the floor, never raises it
+await app.service("products").patch(id, { $min: { lowestPrice: 9.99 } });
+
+// only raises the high score, never lowers it
+await app.service("games").patch(id, { $max: { highScore: 4200 } });
+```
+
+Operators combine with each other and with plain values in a single patch:
+
+```ts
+// SET name = 'Sale', price = price * 0.8, sold = sold + 1
+await app.service("products").patch(id, {
+  name: "Sale",
+  $mul: { price: 0.8 },
+  $inc: { sold: 1 },
+});
+```
+
+Because the work happens in the database, it is safe under concurrency — two
+simultaneous `{ $inc: { views: 1 } }` patches both count, with no read-modify-write
+race. It also applies to **multi-patch** (every matched row is updated):
+
+```ts
+// every active user's loginCount goes up by 1
+await app
+  .service("users")
+  .patch(null, { $inc: { loginCount: 1 } }, { query: { active: true } });
+```
+
+## Array operators (`$push` / `$pull`)
+
+`$push` appends to an array column, `$pull` removes matching elements. A scalar
+value affects one element; an array value affects each:
+
+```ts
+// append one tag, or several
+await app.service("posts").patch(id, { $push: { tags: "kysely" } });
+await app.service("posts").patch(id, { $push: { tags: ["sql", "node"] } });
+
+// remove one value (all occurrences), or several
+await app.service("posts").patch(id, { $pull: { tags: "draft" } });
+await app.service("posts").patch(id, { $pull: { tags: ["draft", "wip"] } });
+```
+
+### Column type detection
+
+The SQL differs completely between a **native Postgres array** (`text[]`,
+`integer[]`, …) and a **`json` / `jsonb`** column, so the operator must know the
+column's storage. It resolves the type per column the same way the query
+operators do — from a `getPropertyType` option, or an `x-db-type` annotation in
+the service's `properties`:
+
+```ts
+new KyselyService({
+  Model: db,
+  name: "posts",
+  properties: {
+    tags: { type: "array", "x-db-type": "text[]" }, // native Postgres array
+    labels: { type: "array", "x-db-type": "jsonb" }, // jsonb array
+  },
+});
+```
+
+If a column's storage can't be determined, `$push` / `$pull` throw a
+`BadRequest` rather than guessing.
+
+### Support matrix
+
+| Column storage           | `$push`             | `$pull`             |
+| ------------------------ | ------------------- | ------------------- |
+| Postgres native array    | ✅ Postgres only    | ✅ Postgres only    |
+| `json` / `jsonb`         | ✅ all dialects     | ✅ **Postgres only** |
+
+- Native array ops use `array_append` / `array_remove` / `||` and exist only on
+  PostgreSQL (other dialects throw `BadRequest`).
+- JSON `$push` works on all dialects (`||` on Postgres, `json_array_append` on
+  MySQL, `json_insert` on SQLite).
+- JSON `$pull` is **Postgres-only** (a `jsonb_agg` filter); on MySQL / SQLite it
+  throws `BadRequest`, as it can't be expressed as a single statement.
+
+## patch only {#patch-only}
+
+Operators are only meaningful for `patch` (a partial update). `update` replaces
+the entire record, so an operator there is almost certainly a mistake — using one
+on `update` throws a `BadRequest`. Register the hook on `update` as well to get
+that clear error rather than a confusing database failure.
+
+## Validation
+
+Invalid payloads throw a `BadRequest`:
+
+- the operator value must be an object (`{ $inc: 5 }` is rejected);
+- for `$inc` / `$mul` / `$min` / `$max`, each target value must be a finite
+  number (`{ $inc: { age: "x" } }`, `NaN`, and `Infinity` are rejected);
+- for `$push` / `$pull`, the value must be defined, and the column's storage
+  must be detectable (see [above](#column-type-detection)).
+
+## TypeScript
+
+`PatchData<T>` is `Partial<T>`, so the operator keys are not part of the static
+type. Cast at the call site when needed:
+
+```ts
+await app.service("products").patch(id, { $inc: { stock: -1 } } as any);
+```
+
+## Dialects
+
+`$inc` / `$mul` / `$min` / `$max` work on all dialects (PostgreSQL, MySQL,
+SQLite) — the generated arithmetic / `CASE` is standard SQL, and every value is
+bound as a parameter. `$push` / `$pull` are dialect- and storage-specific; see
+the [support matrix](#support-matrix) above.

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -813,7 +813,7 @@ export class KyselyAdapter<
    * annotation on the column's entry in `properties` (typically the service's
    * JSON schema `properties` block).
    */
-  private getPropertyType(property: string): string | undefined {
+  getPropertyType(property: string): string | undefined {
     const explicit = this.options.getPropertyType?.(property)
     if (explicit != null) return explicit
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './with-transaction.js'
+export * from './update-operators.js'

--- a/src/hooks/update-operators.ts
+++ b/src/hooks/update-operators.ts
@@ -1,0 +1,62 @@
+import { _ } from '@feathersjs/commons'
+import { BadRequest } from '@feathersjs/errors'
+import type { HookContext, NextFunction } from '@feathersjs/feathers'
+import type { DialectType } from '../declarations.js'
+import { applyUpdateOperators, containsUpdateOperator } from '../utils/index.js'
+
+// The slice of the Kysely service the hook reads to drive $push/$pull.
+interface KyselyUpdateService {
+  options?: { dialectType?: DialectType }
+  getPropertyType?: (column: string) => string | undefined
+}
+
+/**
+ * Hook that rewrites MongoDB-style update operators in `context.data` into
+ * atomic Kysely SET expressions:
+ *
+ * - `$inc` / `$mul` — add / multiply, e.g. `{ $inc: { views: 1 } }`;
+ * - `$min` / `$max` — clamp to the smaller / larger value;
+ * - `$push` / `$pull` — append to / remove from an array column. The SQL is
+ *   chosen per column from its detected storage (native Postgres array vs.
+ *   `json`/`jsonb`) and the dialect, via the service's `getPropertyType`.
+ *
+ * Usable as either a `before` hook or an `around` hook — `next` is optional, and
+ * when present (around) it is awaited after the data has been transformed:
+ *
+ *   service.hooks({ before: { patch: [updateOperators()] } })
+ *   // or
+ *   service.hooks({ around: { patch: [updateOperators()] } })
+ *
+ * Operators are only meaningful for `patch` (a partial update); `update`
+ * replaces the whole record, so operators there are rejected with a
+ * `BadRequest`. Register on both methods to surface that error clearly.
+ *
+ * Invalid payloads (non-object operator, non-finite number, undefined array
+ * value, undetectable array column) throw `BadRequest`.
+ */
+export const updateOperators =
+  () =>
+  async (context: HookContext, next?: NextFunction): Promise<HookContext> => {
+    const { method, data } = context
+
+    if (data && !Array.isArray(data) && _.isObject(data)) {
+      if (method === 'patch') {
+        const service = context.service as unknown as KyselyUpdateService
+        context.data = applyUpdateOperators(data as Record<string, any>, {
+          dialectType: service.options?.dialectType,
+          getColumnType: service.getPropertyType?.bind(service),
+        })
+      } else if (
+        method === 'update' &&
+        containsUpdateOperator(data as Record<string, any>)
+      ) {
+        throw new BadRequest(
+          'Update operators ($inc/$mul/$min/$max/$push/$pull) are only supported on patch, not update',
+        )
+      }
+    }
+
+    await next?.()
+
+    return context
+  }

--- a/src/hooks/with-transaction.ts
+++ b/src/hooks/with-transaction.ts
@@ -4,7 +4,7 @@ import type { ControlledTransaction, Kysely } from 'kysely'
 import type {
   KyselyAdapterParams,
   KyselyAdapterTransaction,
-} from './declarations.js'
+} from '../declarations.js'
 
 const debug = createDebug('feathers-kysely-transaction')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './declarations.js'
 export * from './adapter.js'
 export * from './error-handler.js'
-export * from './hooks.js'
+export * from './hooks/index.js'
 export * from './service.js'

--- a/src/utils/apply-update-operators.ts
+++ b/src/utils/apply-update-operators.ts
@@ -1,0 +1,257 @@
+import { _ } from '@feathersjs/commons'
+import { BadRequest } from '@feathersjs/errors'
+import type { ExpressionBuilder } from 'kysely'
+import type { DialectType } from '../declarations.js'
+import { buildArrayUpdate } from './build-array-update.js'
+
+type Eb = ExpressionBuilder<any, any>
+
+/**
+ * Replace the column with `value` only when the current value is `null` or
+ * compares to `value` under `cmp` — the portable `$min`/`$max` clamp. `$min`
+ * keeps the smaller value (`cmp = '>'`: replace when current is greater);
+ * `$max` keeps the larger (`cmp = '<'`). Standard SQL `CASE`, all dialects.
+ */
+const clamp = (eb: Eb, key: string, cmp: '>' | '<', value: number) => {
+  const ref = eb.ref(key)
+  return eb
+    .case()
+    .when(eb.or([eb(ref, 'is', null), eb(ref, cmp, value)]))
+    .then(eb.val(value))
+    .else(ref)
+    .end()
+}
+
+// Numeric operators: map a column + finite-number value to a SET expression.
+const NUMERIC_BUILDERS = {
+  $inc: (eb: Eb, key: string, value: number) => eb(eb.ref(key), '+', value),
+  $mul: (eb: Eb, key: string, value: number) => eb(eb.ref(key), '*', value),
+  $min: (eb: Eb, key: string, value: number) => clamp(eb, key, '>', value),
+  $max: (eb: Eb, key: string, value: number) => clamp(eb, key, '<', value),
+} as const
+
+// Array operators: handled by buildArrayUpdate (dialect + column-type aware).
+const ARRAY_OPERATORS = ['$push', '$pull'] as const
+
+type NumericOperator = keyof typeof NUMERIC_BUILDERS
+type ArrayOperator = (typeof ARRAY_OPERATORS)[number]
+type UpdateOperator = NumericOperator | ArrayOperator
+
+export const UPDATE_OPERATOR_KEYS = [
+  ...(Object.keys(NUMERIC_BUILDERS) as NumericOperator[]),
+  ...ARRAY_OPERATORS,
+] as UpdateOperator[]
+
+/** True when `data` carries at least one update operator (`$inc`/`$mul`/`$min`/`$max`/`$push`/`$pull`). */
+export const containsUpdateOperator = (data: Record<string, any>): boolean =>
+  UPDATE_OPERATOR_KEYS.some((op) => op in data)
+
+export interface ApplyUpdateOperatorsOptions {
+  /** SQL dialect — required for the `$push`/`$pull` array operators. */
+  dialectType?: DialectType
+  /**
+   * Resolve a column's database type (e.g. `'jsonb'`, `'text[]'`) so `$push` /
+   * `$pull` can pick native-array vs. JSON SQL. Typically the adapter's own
+   * `getPropertyType`.
+   */
+  getColumnType?: (column: string) => string | undefined
+}
+
+/**
+ * Rewrites MongoDB-style update operators into atomic Kysely SET expressions:
+ *
+ *   { $inc: { views: 1 }, $mul: { price: 2 } }
+ *     -> { views: (eb) => eb('views', '+', 1), price: (eb) => eb('price', '*', 2) }
+ *
+ * Supported:
+ * - `$inc` (add), `$mul` (multiply), `$min`/`$max` (clamp to the smaller/larger
+ *   of the current value and `value`) — portable, no options needed;
+ * - `$push`/`$pull` (append to / remove from an array column) — these need
+ *   `options.dialectType` and `options.getColumnType` to choose native-array
+ *   vs. JSON SQL per column (see {@link buildArrayUpdate}).
+ *
+ * The resulting per-column factories are passed straight through to Kysely's
+ * `.set()` (the adapter never touches function values). A new object is returned
+ * only when an operator was present; otherwise the input is returned untouched.
+ *
+ * Throws `BadRequest` when an operator payload is not a plain object, a numeric
+ * target value is not finite, or an array target is `undefined`.
+ */
+export function applyUpdateOperators<D extends Record<string, any>>(
+  data: D,
+  options: ApplyUpdateOperatorsOptions = {},
+): D {
+  let result = data
+  let copied = false
+
+  for (const op of UPDATE_OPERATOR_KEYS) {
+    if (!(op in data)) {
+      continue
+    }
+
+    const values = data[op]
+    if (!_.isObject(values) || Array.isArray(values)) {
+      throw new BadRequest(`The value for '${op}' must be an object`)
+    }
+
+    if (!copied) {
+      result = { ...data }
+      copied = true
+    }
+
+    for (const key of Object.keys(values)) {
+      const value = (values as Record<string, unknown>)[key]
+
+      if (op === '$push' || op === '$pull') {
+        if (value === undefined) {
+          throw new BadRequest(
+            `The value for '${op}.${key}' must not be undefined`,
+          )
+        }
+        ;(result as Record<string, any>)[key] = () =>
+          buildArrayUpdate({
+            key,
+            operator: op,
+            value,
+            dialectType: options.dialectType,
+            columnType: options.getColumnType?.(key),
+          })
+        continue
+      }
+
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new BadRequest(
+          `The value for '${op}.${key}' must be a finite number`,
+        )
+      }
+
+      const build = NUMERIC_BUILDERS[op]
+      ;(result as Record<string, any>)[key] = (eb: Eb) => build(eb, key, value)
+    }
+
+    delete (result as Record<string, any>)[op]
+  }
+
+  return result
+}
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest
+  const {
+    Kysely,
+    DummyDriver,
+    PostgresAdapter,
+    PostgresIntrospector,
+    PostgresQueryCompiler,
+    SqliteAdapter,
+    SqliteIntrospector,
+    SqliteQueryCompiler,
+  } = await import('kysely')
+
+  const mk = (Adapter: any, Introspector: any, Compiler: any) =>
+    new Kysely<any>({
+      dialect: {
+        createAdapter: () => new Adapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (db: any) => new Introspector(db),
+        createQueryCompiler: () => new Compiler(),
+      },
+    })
+  const pg = mk(PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler)
+  const sqlite = mk(SqliteAdapter, SqliteIntrospector, SqliteQueryCompiler)
+
+  const compile = (db: any, data: any) =>
+    db.updateTable('t').set(applyUpdateOperators(data)).compile()
+
+  describe('applyUpdateOperators', () => {
+    it('rewrites $inc into an atomic SET (Postgres)', () => {
+      const { sql, parameters } = compile(pg, { $inc: { age: 1 } })
+      expect(sql).toMatch(/set "age" = \(?"age" \+ \$1\)?/)
+      expect(parameters).toEqual([1])
+    })
+
+    it('rewrites $mul into an atomic SET (Postgres)', () => {
+      const { sql, parameters } = compile(pg, { $mul: { price: 2 } })
+      expect(sql).toMatch(/set "price" = \(?"price" \* \$1\)?/)
+      expect(parameters).toEqual([2])
+    })
+
+    it('binds a negative $inc as a parameter (decrement)', () => {
+      const { sql, parameters } = compile(pg, { $inc: { age: -5 } })
+      expect(sql).toMatch(/set "age" = \(?"age" \+ \$1\)?/)
+      expect(parameters).toEqual([-5])
+    })
+
+    it('compiles on SQLite (standard arithmetic, ? placeholders)', () => {
+      const { sql, parameters } = compile(sqlite, { $inc: { age: 1 } })
+      expect(sql).toMatch(/set "age" = \(?"age" \+ \?\)?/)
+      expect(parameters).toEqual([1])
+    })
+
+    it('rewrites $min into a portable clamping CASE (Postgres)', () => {
+      const { sql, parameters } = compile(pg, { $min: { stock: 5 } })
+      expect(sql).toContain(
+        'set "stock" = case when ("stock" is null or "stock" > $1) then $2 else "stock" end',
+      )
+      expect(parameters).toEqual([5, 5])
+    })
+
+    it('rewrites $max into a portable clamping CASE (Postgres)', () => {
+      const { sql, parameters } = compile(pg, { $max: { peak: 100 } })
+      expect(sql).toContain(
+        'set "peak" = case when ("peak" is null or "peak" < $1) then $2 else "peak" end',
+      )
+      expect(parameters).toEqual([100, 100])
+    })
+
+    it('$min / $max compile on SQLite (? placeholders)', () => {
+      const { sql, parameters } = compile(sqlite, { $max: { peak: 7 } })
+      expect(sql).toContain(
+        'set "peak" = case when ("peak" is null or "peak" < ?) then ? else "peak" end',
+      )
+      expect(parameters).toEqual([7, 7])
+    })
+
+    it('keeps literal columns and drops the operator key', () => {
+      const result = applyUpdateOperators({
+        name: 'x',
+        $inc: { age: 1 },
+      }) as Record<string, any>
+      expect(result.name).toBe('x')
+      expect('$inc' in result).toBe(false)
+      expect(typeof result.age).toBe('function')
+    })
+
+    it('returns the same reference when no operator is present', () => {
+      const data = { name: 'x', age: 5 }
+      expect(applyUpdateOperators(data)).toBe(data)
+    })
+
+    it('throws BadRequest when the operator payload is not an object', () => {
+      expect(() => applyUpdateOperators({ $inc: 5 as any })).toThrow(
+        "The value for '$inc' must be an object",
+      )
+      expect(() => applyUpdateOperators({ $inc: [1, 2] as any })).toThrow(
+        /must be an object/,
+      )
+    })
+
+    it('throws BadRequest for non-finite / non-numeric values', () => {
+      expect(() => applyUpdateOperators({ $inc: { age: 'x' as any } })).toThrow(
+        "The value for '$inc.age' must be a finite number",
+      )
+      expect(() => applyUpdateOperators({ $inc: { age: Number.NaN } })).toThrow(
+        /must be a finite number/,
+      )
+      expect(() =>
+        applyUpdateOperators({ $mul: { age: Number.POSITIVE_INFINITY } }),
+      ).toThrow(/must be a finite number/)
+    })
+
+    it('detects operators via containsUpdateOperator', () => {
+      expect(containsUpdateOperator({ $inc: { a: 1 } })).toBe(true)
+      expect(containsUpdateOperator({ $mul: { a: 1 } })).toBe(true)
+      expect(containsUpdateOperator({ a: 1 })).toBe(false)
+    })
+  })
+}

--- a/src/utils/build-array-update.ts
+++ b/src/utils/build-array-update.ts
@@ -1,0 +1,340 @@
+import { sql } from 'kysely'
+import { BadRequest } from '@feathersjs/errors'
+import type { RawBuilder } from 'kysely'
+import type { DialectType } from '../declarations.js'
+import { isPostgresArrayType } from './is-postgres-array-type.js'
+
+export type ArrayUpdateOperator = '$push' | '$pull'
+
+/**
+ * Build the SET expression for the array update operators `$push` / `$pull`,
+ * choosing the SQL per **detected column storage**:
+ *
+ * - a native Postgres array column (`text[]`, `varchar(255)[]`, … — recognized
+ *   via `isPostgresArrayType`) uses `array_append` / `array_remove` / `||`;
+ * - a `json` / `jsonb` column uses the dialect's JSON functions.
+ *
+ * A scalar `value` appends/removes one element; an array `value` appends each
+ * (`$push`) or removes every listed element (`$pull`).
+ *
+ * Throws `BadRequest` when the storage can't be determined (no `x-db-type` /
+ * `getPropertyType`), when a native-array op is used off Postgres, or when
+ * `$pull` targets a JSON column on MySQL/SQLite (not expressible in one
+ * statement there).
+ */
+export function buildArrayUpdate(opts: {
+  key: string
+  operator: ArrayUpdateOperator
+  value: unknown
+  dialectType: DialectType | undefined
+  columnType: string | undefined
+}): RawBuilder<unknown> {
+  const { key, operator, value, dialectType, columnType } = opts
+  const ref = sql.ref(key)
+  const items = Array.isArray(value) ? value : [value]
+
+  // --- Native Postgres array column (text[], varchar(255)[], bigint[], …) ---
+  if (isPostgresArrayType(columnType)) {
+    if (dialectType !== 'postgres') {
+      throw new BadRequest(
+        `Native array operators require the postgres dialect (column '${key}' is '${columnType}')`,
+      )
+    }
+    const arrType = columnType.trim()
+
+    if (operator === '$push') {
+      if (!Array.isArray(value)) {
+        return sql`array_append(${ref}, ${value})`
+      }
+      // push each: concat a typed array literal
+      return sql`${ref} || ARRAY[${sql.join(value)}]::${sql.raw(arrType)}`
+    }
+
+    // $pull: fold array_remove so every listed element is removed
+    let expr: RawBuilder<unknown> = ref
+    for (const item of items) {
+      expr = sql`array_remove(${expr}, ${item})`
+    }
+    return expr
+  }
+
+  // --- JSON / JSONB column ---
+  if (columnType === 'json' || columnType === 'jsonb') {
+    return operator === '$push'
+      ? buildJsonPush(ref, items, columnType, dialectType)
+      : buildJsonPull(ref, items, columnType, dialectType, key)
+  }
+
+  throw new BadRequest(
+    `Cannot determine array storage for column '${key}'. Annotate it with an 'x-db-type' (e.g. 'jsonb' or 'text[]') or provide a getPropertyType option to use '${operator}'.`,
+  )
+}
+
+function buildJsonPush(
+  ref: RawBuilder<unknown>,
+  items: unknown[],
+  columnType: 'json' | 'jsonb',
+  dialectType: DialectType | undefined,
+): RawBuilder<unknown> {
+  if (dialectType === 'postgres') {
+    // Concat a JSON array literal (one element per item). Going through
+    // JSON.stringify preserves each element's JS type, and computing in jsonb +
+    // casting back keeps the assignment valid for a `json` column too.
+    return sql`(${ref}::jsonb || ${JSON.stringify(items)}::jsonb)::${sql.raw(columnType)}`
+  }
+
+  if (dialectType === 'mysql') {
+    let expr: RawBuilder<unknown> = ref
+    for (const item of items) {
+      expr = sql`json_array_append(${expr}, ${'$'}, ${item})`
+    }
+    return expr
+  }
+
+  // sqlite: json_insert appends with the '$[#]' end-of-array path; multiple
+  // path/value pairs append several at once.
+  const pairs = items.flatMap((item) => [sql`${'$[#]'}`, sql`${item}`])
+  return sql`json_insert(${ref}, ${sql.join(pairs)})`
+}
+
+function buildJsonPull(
+  ref: RawBuilder<unknown>,
+  items: unknown[],
+  columnType: 'json' | 'jsonb',
+  dialectType: DialectType | undefined,
+  key: string,
+): RawBuilder<unknown> {
+  if (dialectType !== 'postgres') {
+    throw new BadRequest(
+      `'$pull' on a JSON column is only supported on the postgres dialect (column '${key}')`,
+    )
+  }
+
+  const remove = sql`${JSON.stringify(items)}::jsonb`
+  // rebuild the array keeping only elements not present in the remove-set
+  return sql`(
+    select coalesce(jsonb_agg(t.v), '[]'::jsonb)
+    from jsonb_array_elements(${ref}::jsonb) as t(v)
+    where t.v <> all(array(select r.v from jsonb_array_elements(${remove}) as r(v)))
+  )::${sql.raw(columnType)}`
+}
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest
+  const {
+    Kysely,
+    DummyDriver,
+    PostgresAdapter,
+    PostgresIntrospector,
+    PostgresQueryCompiler,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+    SqliteAdapter,
+    SqliteIntrospector,
+    SqliteQueryCompiler,
+  } = await import('kysely')
+
+  const mk = (Adapter: any, Introspector: any, Compiler: any) =>
+    new Kysely<any>({
+      dialect: {
+        createAdapter: () => new Adapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (db: any) => new Introspector(db),
+        createQueryCompiler: () => new Compiler(),
+      },
+    })
+  const pg = mk(PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler)
+  const mysql = mk(MysqlAdapter, MysqlIntrospector, MysqlQueryCompiler)
+  const sqlite = mk(SqliteAdapter, SqliteIntrospector, SqliteQueryCompiler)
+
+  const compile = (db: any, opts: any) => buildArrayUpdate(opts).compile(db)
+
+  describe('buildArrayUpdate', () => {
+    describe('native Postgres array', () => {
+      it('$push scalar -> array_append', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$push',
+          value: 'x',
+          dialectType: 'postgres',
+          columnType: 'text[]',
+        })
+        expect(text).toBe('array_append("tags", $1)')
+        expect(parameters).toEqual(['x'])
+      })
+
+      it('$push array -> typed concat (push each)', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$push',
+          value: ['a', 'b'],
+          dialectType: 'postgres',
+          columnType: 'varchar(255)[]',
+        })
+        expect(text).toBe('"tags" || ARRAY[$1, $2]::varchar(255)[]')
+        expect(parameters).toEqual(['a', 'b'])
+      })
+
+      it('$pull scalar -> array_remove', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$pull',
+          value: 'x',
+          dialectType: 'postgres',
+          columnType: 'text[]',
+        })
+        expect(text).toBe('array_remove("tags", $1)')
+        expect(parameters).toEqual(['x'])
+      })
+
+      it('$pull array -> folded array_remove', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$pull',
+          value: ['a', 'b'],
+          dialectType: 'postgres',
+          columnType: 'text[]',
+        })
+        expect(text).toBe('array_remove(array_remove("tags", $1), $2)')
+        expect(parameters).toEqual(['a', 'b'])
+      })
+
+      it('rejects a native-array op off Postgres', () => {
+        expect(() =>
+          compile(sqlite, {
+            key: 'tags',
+            operator: '$push',
+            value: 'x',
+            dialectType: 'sqlite',
+            columnType: 'text[]',
+          }),
+        ).toThrow(/require the postgres dialect/)
+      })
+    })
+
+    describe('jsonb (Postgres)', () => {
+      it('$push scalar -> jsonb concat', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$push',
+          value: 'x',
+          dialectType: 'postgres',
+          columnType: 'jsonb',
+        })
+        expect(text).toBe('("tags"::jsonb || $1::jsonb)::jsonb')
+        expect(parameters).toEqual(['["x"]'])
+      })
+
+      it('$push array -> jsonb array concat', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$push',
+          value: ['a', 'b'],
+          dialectType: 'postgres',
+          columnType: 'json',
+        })
+        expect(text).toBe('("tags"::jsonb || $1::jsonb)::json')
+        expect(parameters).toEqual(['["a","b"]'])
+      })
+
+      it('$pull -> jsonb_agg filter, cast back to the column type', () => {
+        const { sql: text, parameters } = compile(pg, {
+          key: 'tags',
+          operator: '$pull',
+          value: 'x',
+          dialectType: 'postgres',
+          columnType: 'jsonb',
+        })
+        expect(text).toContain('jsonb_agg(t.v)')
+        expect(text).toContain('jsonb_array_elements("tags"::jsonb) as t(v)')
+        expect(text).toContain(
+          '<> all(array(select r.v from jsonb_array_elements($1::jsonb) as r(v)))',
+        )
+        expect(text.trimEnd().endsWith(')::jsonb')).toBe(true)
+        expect(parameters).toEqual(['["x"]'])
+      })
+    })
+
+    describe('JSON on MySQL / SQLite', () => {
+      it('MySQL $push scalar -> json_array_append', () => {
+        const { sql: text, parameters } = compile(mysql, {
+          key: 'tags',
+          operator: '$push',
+          value: 'x',
+          dialectType: 'mysql',
+          columnType: 'json',
+        })
+        expect(text).toBe('json_array_append(`tags`, ?, ?)')
+        expect(parameters).toEqual(['$', 'x'])
+      })
+
+      it('MySQL $push array -> chained json_array_append', () => {
+        const { sql: text, parameters } = compile(mysql, {
+          key: 'tags',
+          operator: '$push',
+          value: ['a', 'b'],
+          dialectType: 'mysql',
+          columnType: 'json',
+        })
+        expect(text).toBe(
+          'json_array_append(json_array_append(`tags`, ?, ?), ?, ?)',
+        )
+        expect(parameters).toEqual(['$', 'a', '$', 'b'])
+      })
+
+      it('SQLite $push scalar -> json_insert', () => {
+        const { sql: text, parameters } = compile(sqlite, {
+          key: 'tags',
+          operator: '$push',
+          value: 'x',
+          dialectType: 'sqlite',
+          columnType: 'json',
+        })
+        expect(text).toBe('json_insert("tags", ?, ?)')
+        expect(parameters).toEqual(['$[#]', 'x'])
+      })
+
+      it('SQLite $push array -> json_insert with multiple pairs', () => {
+        const { sql: text, parameters } = compile(sqlite, {
+          key: 'tags',
+          operator: '$push',
+          value: ['a', 'b'],
+          dialectType: 'sqlite',
+          columnType: 'json',
+        })
+        expect(text).toBe('json_insert("tags", ?, ?, ?, ?)')
+        expect(parameters).toEqual(['$[#]', 'a', '$[#]', 'b'])
+      })
+
+      it('rejects $pull on a JSON column off Postgres', () => {
+        for (const [db, dialectType] of [
+          [mysql, 'mysql'],
+          [sqlite, 'sqlite'],
+        ] as const) {
+          expect(() =>
+            compile(db, {
+              key: 'tags',
+              operator: '$pull',
+              value: 'x',
+              dialectType,
+              columnType: 'json',
+            }),
+          ).toThrow(/only supported on the postgres dialect/)
+        }
+      })
+    })
+
+    it('throws when the column storage cannot be determined', () => {
+      expect(() =>
+        compile(pg, {
+          key: 'tags',
+          operator: '$push',
+          value: 'x',
+          dialectType: 'postgres',
+          columnType: undefined,
+        }),
+      ).toThrow(/Cannot determine array storage for column 'tags'/)
+    })
+  })
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,6 @@
 export * from './apply-select-id.js'
+export * from './apply-update-operators.js'
+export * from './build-array-update.js'
 export * from './traverse-json.js'
 export * from './convert-booleans-to-numbers.js'
 export * from './temporal-kind.js'

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -15,12 +15,15 @@ describe('exports', () => {
         // service.ts
         'KyselyService',
 
-        // hooks.ts
+        // hooks/with-transaction.ts
         'getKysely',
         'trxCommit',
         'trxRollback',
         'trxStart',
         'withTransaction',
+
+        // hooks/update-operators.ts
+        'updateOperators',
       ].sort(),
     )
   })

--- a/test/expression-values.test.ts
+++ b/test/expression-values.test.ts
@@ -1,0 +1,119 @@
+import type { ExpressionBuilder, Generated } from 'kysely'
+import { Kysely } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import dialect from './dialect.js'
+import { KyselyService } from '../src/index.js'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { addPrimaryKey } from './test-utils.js'
+
+type Eb = ExpressionBuilder<any, any>
+
+interface UsersTable {
+  id: Generated<number>
+  name: string
+  age: number | null
+  score: number | null
+}
+interface DB {
+  users: UsersTable
+}
+type User = {
+  id: number
+  name: string
+  age: number | null
+  score: number | null
+}
+
+function setup() {
+  const db = new Kysely<DB>({ dialect: dialect() })
+
+  const clean = async () => {
+    await db.schema.dropTable('users').ifExists().execute()
+    await addPrimaryKey(
+      db.schema
+        .createTable('users')
+        .addColumn('name', 'text', (col) => col.notNull())
+        .addColumn('age', 'integer')
+        .addColumn('score', 'integer'),
+      'id',
+    ).execute()
+  }
+
+  const users = new KyselyService<User>({
+    Model: db,
+    name: 'users',
+    multi: true,
+    properties: { id: true, name: true, age: true, score: true },
+  })
+
+  const app = feathers<{ users: typeof users }>().use('users', users)
+  return { app, db, clean }
+}
+
+const { app, db, clean } = setup()
+
+// A column value can be a Kysely expression-builder factory `(eb) => Expression`
+// passed straight through `.values()` (create) and `.set()` (patch/update). This
+// is the server-side escape hatch for DB-computed values (e.g. column-to-column
+// copies, SQL functions) — no hook or operator required. The function form is
+// what reliably survives the adapter's SQLite `convertValues` pass.
+describe('expression / factory column values (cross-dialect)', () => {
+  beforeEach(clean)
+  afterAll(() => db.destroy())
+
+  it('create accepts a factory value computed in the database', async () => {
+    const created = await app.service('users').create({
+      name: 'a',
+      age: ((eb: Eb) => eb(eb.lit(5), '+', eb.lit(5))) as any,
+    })
+
+    // resolved by the DB (insert ... values (..., (5 + 5))) and returned
+    expect(created.age).toBe(10)
+  })
+
+  it('patch accepts (eb) => eb.ref(...) (column-to-column copy)', async () => {
+    const created = await app
+      .service('users')
+      .create({ name: 'a', age: 7, score: 1 })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { score: ((eb: Eb) => eb.ref('age')) as any })
+
+    // set "score" = "age"
+    expect(patched.score).toBe(7)
+  })
+
+  it('update accepts a factory value (survives the full-replace path)', async () => {
+    const created = await app
+      .service('users')
+      .create({ name: 'a', age: 9, score: 1 })
+
+    const updated = await app.service('users').update(created.id, {
+      name: 'a',
+      age: 9,
+      score: ((eb: Eb) => eb.ref('age')) as any,
+    })
+
+    expect(updated.score).toBe(9)
+    expect(updated.age).toBe(9)
+  })
+
+  it('applies a factory value to every matched row in a multi-patch', async () => {
+    await app.service('users').create([
+      { name: 'a', age: 1, score: 0 },
+      { name: 'b', age: 2, score: 0 },
+      { name: 'c', age: 3, score: 0 },
+    ])
+
+    const patched = await app.service('users').patch(
+      null,
+      { score: ((eb: Eb) => eb.ref('age')) as any },
+      {
+        query: { $sort: { age: 1 } },
+      },
+    )
+
+    expect((patched as User[]).map((u) => u.score)).toEqual([1, 2, 3])
+  })
+})

--- a/test/update-array-operators.test.ts
+++ b/test/update-array-operators.test.ts
@@ -1,0 +1,194 @@
+import type { Generated } from 'kysely'
+import { Kysely, sql } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import dialect, { getDialect } from './dialect.js'
+import { KyselyService, updateOperators } from '../src/index.js'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { addPrimaryKey } from './test-utils.js'
+
+const dialectName = getDialect()
+
+// --- Postgres: native arrays (text[]) and jsonb arrays -----------------------
+describe.skipIf(dialectName !== 'postgres')(
+  'update array operators — Postgres (native arrays + jsonb)',
+  () => {
+    interface DB {
+      arr_test: {
+        id: Generated<number>
+        tags: string[]
+        labels: any
+      }
+    }
+    const db = new Kysely<DB>({ dialect: dialect() })
+
+    const clean = async () => {
+      await db.schema.dropTable('arr_test').ifExists().execute()
+      await db.schema
+        .createTable('arr_test')
+        .addColumn('id', 'serial', (c) => c.primaryKey())
+        .addColumn('tags', sql`text[]`)
+        .addColumn('labels', 'jsonb')
+        .execute()
+    }
+
+    const service = new KyselyService<any>({
+      Model: db,
+      id: 'id',
+      name: 'arr_test',
+      multi: true,
+      properties: {
+        tags: { type: 'array', 'x-db-type': 'text[]' },
+        labels: { type: 'array', 'x-db-type': 'jsonb' },
+      },
+    })
+    const app = feathers().use('arr_test', service)
+    app.service('arr_test').hooks({ before: { patch: [updateOperators()] } })
+
+    beforeEach(clean)
+    afterAll(() => db.destroy())
+
+    const seed = async (tags: string[], labels: any[]) => {
+      const row = await db
+        .insertInto('arr_test')
+        .values({
+          tags: tags as any,
+          labels: sql`${JSON.stringify(labels)}::jsonb` as any,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+      return row.id
+    }
+    const read = (id: number) =>
+      db
+        .selectFrom('arr_test')
+        .selectAll()
+        .where('id', '=', id)
+        .executeTakeFirstOrThrow()
+
+    it('$push appends a scalar to a native text[] column', async () => {
+      const id = await seed(['a'], [])
+      await app.service('arr_test').patch(id, { $push: { tags: 'b' } } as any)
+      expect((await read(id)).tags).toEqual(['a', 'b'])
+    })
+
+    it('$push appends several to a native text[] column', async () => {
+      const id = await seed(['a'], [])
+      await app
+        .service('arr_test')
+        .patch(id, { $push: { tags: ['b', 'c'] } } as any)
+      expect((await read(id)).tags).toEqual(['a', 'b', 'c'])
+    })
+
+    it('$pull removes every occurrence from a native text[] column', async () => {
+      const id = await seed(['a', 'b', 'a', 'c'], [])
+      await app.service('arr_test').patch(id, { $pull: { tags: 'a' } } as any)
+      expect((await read(id)).tags).toEqual(['b', 'c'])
+    })
+
+    it('$pull removes several values from a native text[] column', async () => {
+      const id = await seed(['a', 'b', 'c', 'd'], [])
+      await app
+        .service('arr_test')
+        .patch(id, { $pull: { tags: ['a', 'c'] } } as any)
+      expect((await read(id)).tags).toEqual(['b', 'd'])
+    })
+
+    it('$push appends to a jsonb array column', async () => {
+      const id = await seed([], ['x'])
+      await app.service('arr_test').patch(id, { $push: { labels: 'y' } } as any)
+      expect((await read(id)).labels).toEqual(['x', 'y'])
+    })
+
+    it('$pull removes from a jsonb array column', async () => {
+      const id = await seed([], ['x', 'y', 'x', 'z'])
+      await app.service('arr_test').patch(id, { $pull: { labels: 'x' } } as any)
+      expect((await read(id)).labels).toEqual(['y', 'z'])
+    })
+  },
+)
+
+// --- SQLite: JSON arrays stored as text --------------------------------------
+describe.skipIf(dialectName !== 'sqlite')(
+  'update array operators — SQLite (JSON)',
+  () => {
+    interface DB {
+      arr_test: { id: Generated<number>; tags: string; plain: string | null }
+    }
+    const db = new Kysely<DB>({ dialect: dialect() })
+
+    const clean = async () => {
+      await db.schema.dropTable('arr_test').ifExists().execute()
+      await addPrimaryKey(
+        db.schema
+          .createTable('arr_test')
+          .addColumn('tags', 'text', (c) => c.notNull().defaultTo('[]'))
+          .addColumn('plain', 'text'),
+        'id',
+      ).execute()
+    }
+
+    const service = new KyselyService<any>({
+      Model: db,
+      id: 'id',
+      name: 'arr_test',
+      multi: true,
+      properties: {
+        tags: { type: 'array', 'x-db-type': 'json' },
+        // `plain` is intentionally left without an x-db-type annotation
+        plain: true,
+      },
+    })
+    const app = feathers().use('arr_test', service)
+    app.service('arr_test').hooks({
+      before: { patch: [updateOperators()], update: [updateOperators()] },
+    })
+
+    beforeEach(clean)
+    afterAll(() => db.destroy())
+
+    const seed = async (tags: any[]) => {
+      const row = await db
+        .insertInto('arr_test')
+        .values({ tags: JSON.stringify(tags) })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+      return row.id
+    }
+    const readTags = async (id: number) => {
+      const row = await db
+        .selectFrom('arr_test')
+        .selectAll()
+        .where('id', '=', id)
+        .executeTakeFirstOrThrow()
+      return JSON.parse(row.tags)
+    }
+
+    it('$push appends a scalar to a JSON array', async () => {
+      const id = await seed(['a'])
+      await app.service('arr_test').patch(id, { $push: { tags: 'b' } } as any)
+      expect(await readTags(id)).toEqual(['a', 'b'])
+    })
+
+    it('$push appends several to a JSON array', async () => {
+      const id = await seed(['a'])
+      await app
+        .service('arr_test')
+        .patch(id, { $push: { tags: ['b', 'c'] } } as any)
+      expect(await readTags(id)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('$pull on a JSON column is rejected on SQLite', async () => {
+      const id = await seed(['a', 'b'])
+      await expect(
+        app.service('arr_test').patch(id, { $pull: { tags: 'a' } } as any),
+      ).rejects.toMatchObject({ name: 'BadRequest' })
+    })
+
+    it('$push on a column with no detectable type is rejected', async () => {
+      const id = await seed([])
+      await expect(
+        app.service('arr_test').patch(id, { $push: { plain: 'x' } } as any),
+      ).rejects.toMatchObject({ name: 'BadRequest' })
+    })
+  },
+)

--- a/test/update-operators.test.ts
+++ b/test/update-operators.test.ts
@@ -1,0 +1,223 @@
+import type { Generated } from 'kysely'
+import { Kysely } from 'kysely'
+import { feathers } from '@feathersjs/feathers'
+import dialect from './dialect.js'
+import { KyselyService, updateOperators } from '../src/index.js'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { addPrimaryKey } from './test-utils.js'
+
+interface UsersTable {
+  id: Generated<number>
+  name: string
+  age: number | null
+  score: number | null
+}
+interface DB {
+  users: UsersTable
+}
+type User = {
+  id: number
+  name: string
+  age: number | null
+  score: number | null
+}
+
+function setup() {
+  const db = new Kysely<DB>({ dialect: dialect() })
+
+  const clean = async () => {
+    await db.schema.dropTable('users').ifExists().execute()
+    await addPrimaryKey(
+      db.schema
+        .createTable('users')
+        .addColumn('name', 'text', (col) => col.notNull())
+        .addColumn('age', 'integer')
+        .addColumn('score', 'integer'),
+      'id',
+    ).execute()
+  }
+
+  const users = new KyselyService<User>({
+    Model: db,
+    name: 'users',
+    multi: true,
+    properties: { id: true, name: true, age: true, score: true },
+  })
+
+  const app = feathers<{ users: typeof users }>().use('users', users)
+  app.service('users').hooks({
+    before: {
+      patch: [updateOperators()],
+      update: [updateOperators()],
+    },
+  })
+  return { app, db, clean }
+}
+
+const { app, db, clean } = setup()
+
+describe('update operators (cross-dialect)', () => {
+  beforeEach(clean)
+  afterAll(() => db.destroy())
+
+  it('$inc increments a column atomically', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { $inc: { age: 5 } } as any)
+
+    expect(patched.age).toBe(15)
+  })
+
+  it('a negative $inc decrements', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { $inc: { age: -4 } } as any)
+
+    expect(patched.age).toBe(6)
+  })
+
+  it('$mul multiplies a column', async () => {
+    const created = await app.service('users').create({ name: 'a', score: 6 })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { $mul: { score: 3 } } as any)
+
+    expect(patched.score).toBe(18)
+  })
+
+  it('$min keeps the smaller of the current and given value', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    // a greater value leaves the column untouched
+    let patched = await app
+      .service('users')
+      .patch(created.id, { $min: { age: 20 } } as any)
+    expect(patched.age).toBe(10)
+
+    // a smaller value replaces it
+    patched = await app
+      .service('users')
+      .patch(created.id, { $min: { age: 4 } } as any)
+    expect(patched.age).toBe(4)
+  })
+
+  it('$max keeps the larger of the current and given value', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    let patched = await app
+      .service('users')
+      .patch(created.id, { $max: { age: 5 } } as any)
+    expect(patched.age).toBe(10)
+
+    patched = await app
+      .service('users')
+      .patch(created.id, { $max: { age: 25 } } as any)
+    expect(patched.age).toBe(25)
+  })
+
+  it('$min / $max initialize a NULL column to the given value', async () => {
+    const created = await app
+      .service('users')
+      .create({ name: 'a', score: null })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { $min: { score: 50 } } as any)
+    expect(patched.score).toBe(50)
+  })
+
+  it('combines $inc and $mul (different columns) in one patch', async () => {
+    const created = await app
+      .service('users')
+      .create({ name: 'a', age: 10, score: 5 })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { $inc: { age: 1 }, $mul: { score: 2 } } as any)
+
+    expect(patched.age).toBe(11)
+    expect(patched.score).toBe(10)
+  })
+
+  it('mixes a literal assignment with an operator', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    const patched = await app
+      .service('users')
+      .patch(created.id, { name: 'b', $inc: { age: 1 } } as any)
+
+    expect(patched.name).toBe('b')
+    expect(patched.age).toBe(11)
+  })
+
+  it('applies the operator to every matched row in a multi-patch', async () => {
+    await app.service('users').create([
+      { name: 'a', age: 1 },
+      { name: 'b', age: 2 },
+      { name: 'c', age: 3 },
+    ])
+
+    const patched = await app
+      .service('users')
+      .patch(null, { $inc: { age: 10 } } as any, {
+        query: { $sort: { age: 1 } },
+      })
+
+    expect((patched as User[]).map((u) => u.age)).toEqual([11, 12, 13])
+  })
+
+  it('rejects update operators on update (full replace) with BadRequest', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    await expect(
+      app.service('users').update(created.id, { $inc: { age: 1 } } as any),
+    ).rejects.toMatchObject({ name: 'BadRequest' })
+  })
+
+  it('rejects a non-numeric operator value with BadRequest', async () => {
+    const created = await app.service('users').create({ name: 'a', age: 10 })
+
+    await expect(
+      app.service('users').patch(created.id, { $inc: { age: 'x' } } as any),
+    ).rejects.toMatchObject({ name: 'BadRequest' })
+  })
+
+  it('also works when registered as an around hook (optional next)', async () => {
+    const aroundUsers = new KyselyService<User>({
+      Model: db,
+      name: 'users',
+      multi: true,
+      properties: { id: true, name: true, age: true, score: true },
+    })
+    const aroundApp = feathers<{ users: typeof aroundUsers }>().use(
+      'users',
+      aroundUsers,
+    )
+    aroundApp.service('users').hooks({
+      around: {
+        patch: [updateOperators()],
+        update: [updateOperators()],
+      },
+    })
+
+    const created = await aroundApp
+      .service('users')
+      .create({ name: 'a', age: 10 })
+
+    const patched = await aroundApp
+      .service('users')
+      .patch(created.id, { $inc: { age: 7 } } as any)
+    expect(patched.age).toBe(17)
+
+    await expect(
+      aroundApp
+        .service('users')
+        .update(created.id, { $inc: { age: 1 } } as any),
+    ).rejects.toMatchObject({ name: 'BadRequest' })
+  })
+})


### PR DESCRIPTION
This pull request adds support for MongoDB-style atomic update operators (like `$inc`, `$mul`, `$min`, `$max`, `$push`, and `$pull`) to the Feathers Kysely adapter, allowing users to perform atomic updates directly in the database using a new `updateOperators` hook. The update operators are documented, type-checked, and implemented in a way that is safe under concurrency and works across SQL dialects where possible. The PR also introduces a new documentation page and refactors the codebase to expose the new hook and its utilities.

**Key changes:**

### Feature: Atomic update operators

* Added a new `updateOperators` hook (`src/hooks/update-operators.ts`) that rewrites MongoDB-style update operators in `patch` data into atomic SQL `SET` expressions, with validation and dialect-aware handling for array columns. Throws clear errors for misuse or invalid payloads.
* Implemented the core logic for parsing and applying update operators in `applyUpdateOperators` and related utilities (`src/utils/apply-update-operators.ts`), with thorough type checking, error handling, and support for all major SQL dialects. Includes unit tests.

### Documentation

* Added a comprehensive documentation page explaining the new update operators, usage examples, validation, dialect support, and type information (`docs/api/update-operators.md`).
* Linked the new documentation page in the API sidebar navigation (`docs/.vitepress/config.ts`).

### API and codebase refactoring

* Made the adapter’s `getPropertyType` method public so it can be used by the update operator utilities (`src/adapter.ts`).
* Refactored the hooks export to use a new `src/hooks/index.ts` barrel, and updated main exports accordingly. [[1]](diffhunk://#diff-b96dae4653c651669a3c7a95ddf01ed8823a967561b1a74951e2640b2bcbc174R1-R2) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R4)
* Moved `with-transaction` hook to its own file for clarity and maintainability (`src/hooks/with-transaction.ts`).

These changes provide a robust, safe, and convenient way for users to perform atomic updates in Feathers services using familiar MongoDB-style operators, with clear documentation and cross-dialect support.