### PR TITLE
feat: $not filter

### DIFF
--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -148,6 +148,29 @@ await app.service("users").find({
 });
 ```
 
+### `$not`
+
+`$not` negates an entire condition object at the database level — it compiles to
+`NOT (...)` around whatever the inner query produces. It is **operator-agnostic**:
+the inner condition can use any operator, nested `$and` / `$or`, or multiple keys.
+
+```ts
+// NOT (age = 20)
+await app.service("users").find({ query: { $not: { age: 20 } } });
+
+// NOT (age > 15) — works with any operator, not just equality
+await app.service("users").find({ query: { $not: { age: { $gt: 15 } } } });
+
+// De Morgan: NOT (age = 10 OR age = 20) === age != 10 AND age != 20
+await app.service("users").find({
+  query: { $not: { $or: [{ age: 10 }, { age: 20 }] } },
+});
+```
+
+Because the whole object is negated as a unit, a **multi-key** condition negates
+the conjunction — `$not: { age: 20, name: "b" }` is `NOT (age = 20 AND name = "b")`,
+not a per-property inversion. An empty `$not: {}` is a no-op.
+
 ## Querying JSON Columns
 
 Once a column is [declared as `json` or `jsonb`](./service#declaring-column-types),

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -151,6 +151,7 @@ export class KyselyAdapter<
       filters: {
         ...options.filters,
         $and: (value: any) => value,
+        $not: (value: any) => value,
       },
       operators: [
         ...new Set([
@@ -170,6 +171,7 @@ export class KyselyAdapter<
           '$none',
           '$some',
           '$every',
+          '$not',
         ]),
       ],
     })
@@ -961,6 +963,14 @@ export class KyselyAdapter<
       }
 
       return subs?.length ? method(subs) : undefined
+    }
+
+    if (queryKey === '$not') {
+      // Negate the whole condition object at the DB level: NOT (k1 AND k2 ...).
+      // Operator-agnostic and correct for multi-key conditions, unlike a
+      // per-property inversion.
+      const result = this.handleQuery(eb, queryProperty, options)
+      return result?.length ? eb.not(eb.and(result)) : undefined
     }
 
     const col = this.col(queryKey, { tableName: options?.tableName })

--- a/test/query-operators.test.ts
+++ b/test/query-operators.test.ts
@@ -76,6 +76,85 @@ describe('query operators (cross-dialect)', () => {
     expect(combined.map((u) => u.name)).toEqual(['a'])
   })
 
+  describe('$not', () => {
+    it('negates a whole condition (single, nested, multi-key)', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 10 },
+        { name: 'b', age: 20 },
+        { name: 'c', age: 20 },
+      ])
+
+      // single key: NOT (age = 20)
+      const single = await app.service('users').find({
+        query: { $not: { age: 20 }, $sort: { name: 1 } },
+        paginate: false,
+      })
+      expect(single.map((u) => u.name)).toEqual(['a'])
+
+      // nested inside $and
+      const nested = await app.service('users').find({
+        query: { $and: [{ $not: { age: 20 } }], $sort: { name: 1 } },
+        paginate: false,
+      })
+      expect(nested.map((u) => u.name)).toEqual(['a'])
+
+      // multi-key: NOT (age = 20 AND name = 'b') keeps 'a' (age!=20) and 'c'
+      // (age=20 but name!='b'). A per-property inversion (age!=20 AND name!='b')
+      // would wrongly drop 'c'.
+      const multi = await app.service('users').find({
+        query: { $not: { age: 20, name: 'b' }, $sort: { name: 1 } },
+        paginate: false,
+      })
+      expect(multi.map((u) => u.name)).toEqual(['a', 'c'])
+    })
+
+    it('is operator-agnostic (negates $gt, not just equality)', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 10 },
+        { name: 'b', age: 20 },
+        { name: 'c', age: 30 },
+      ])
+
+      // NOT (age > 15) keeps only 'a'
+      const result = await app.service('users').find({
+        query: { $not: { age: { $gt: 15 } }, $sort: { name: 1 } },
+        paginate: false,
+      })
+      expect(result.map((u) => u.name)).toEqual(['a'])
+    })
+
+    it('around $or follows De Morgan', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 10 },
+        { name: 'b', age: 20 },
+        { name: 'c', age: 30 },
+      ])
+
+      // NOT (age = 10 OR age = 20) === age != 10 AND age != 20 -> keeps 'c'
+      const result = await app.service('users').find({
+        query: {
+          $not: { $or: [{ age: 10 }, { age: 20 }] },
+          $sort: { name: 1 },
+        },
+        paginate: false,
+      })
+      expect(result.map((u) => u.name)).toEqual(['c'])
+    })
+
+    it('with an empty condition is a no-op', async () => {
+      await app.service('users').create([
+        { name: 'a', age: 10 },
+        { name: 'b', age: 20 },
+      ])
+
+      const result = await app.service('users').find({
+        query: { $not: {}, $sort: { name: 1 } },
+        paginate: false,
+      })
+      expect(result.map((u) => u.name)).toEqual(['a', 'b'])
+    })
+  })
+
   it('$startsWith / $endsWith', async () => {
     await app.service('users').create([
       { name: 'alpha', age: 1 },


### PR DESCRIPTION
This pull request adds support for a new `$not` query operator to the `KyselyAdapter`, allowing users to negate entire query conditions at the database level. The implementation ensures correct behavior for single, nested, and multi-key conditions, and is operator-agnostic. Comprehensive tests are included to verify the new functionality.

### Query Operator Enhancements

* Added support for the `$not` query operator in the `KyselyAdapter`, allowing users to negate whole query conditions, including multi-key and nested queries, in an operator-agnostic way. [[1]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR154) [[2]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR174) [[3]](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccR968-R975)

### Testing

* Added a new test suite for `$not` in `query-operators.test.ts` to verify correct behavior for single key, nested, multi-key, operator-agnostic, De Morgan logic, and empty condition cases.